### PR TITLE
Partial solution to issue #22

### DIFF
--- a/src/qaqc/01-organize_raw_data.Rmd
+++ b/src/qaqc/01-organize_raw_data.Rmd
@@ -155,13 +155,17 @@ field_notes <- read_excel("data/sensor_field_notes.xlsx") %>%
          DT_join = as.character(DT_round),
          site = tolower(site),
          season = year(DT_round)) %>%
-  arrange(DT_round) %>%
-  # binary version of deployed/pulled options. may need to play around with this some
-  # more
+  arrange(site, DT_round) %>% 
+  group_by(site) %>%
+  # this will pad DT_round grouped by site to determine when the sonde was deployed for that site
+  pad(by = "DT_round", interval = "15 min") %>%
+  # `where` determines if the sonde is deployed or not. 0 = sonde deployed, 1 = sonde is not deployed
   mutate(where = case_when(!is.na(sensor_pulled) & !is.na(sensor_deployed) ~ 0,
                            !is.na(sensor_pulled) & is.na(sensor_deployed) ~ 1,
                            is.na(sensor_pulled) & !is.na(sensor_deployed) ~ 0,
-                           is.na(sensor_pulled) & is.na(sensor_deployed) ~ 0)) 
+                           is.na(sensor_pulled) & is.na(sensor_deployed) ~ NA)) %>% # NA will get filled with previous record
+  # Fill in NA's with the same rules as locf.
+  fill(where) 
 ```
 
 Munge field notes


### PR DESCRIPTION
This PR replaces the `setnafill()` method that was used to fill in NAs in the `where` column of `field_notes` with `fill()` from dplyr from issue 22. 

The exact location where `setnafill()` was used from the original issue 22 has not been replaced yet. Instead, this step has been added onto the `Load field notes` step, where the field notes data has been padded and rearranged so that this new `field_notes` df can be joined onto `all_data` earlier in the data pipeline. 

Note: both this and the previous method that was used are only accurate if the original field notes excel sheet is accurate. That should be checked to make sure that the `sonde_pulled` and `sonde_deployed` columns are accurate. For this reason I have decided to omit the option `.direction = "downup"` from `fill()`, for now.

This is progress on #22.