### PR TITLE
Automating field notes using mWater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ data
 .DS_Store
 images/
 .DS_Store data
+src/mWater_collate/mWater_API.yml

--- a/scratch/data_tidying/timelapse_folder_rename.R
+++ b/scratch/data_tidying/timelapse_folder_rename.R
@@ -1,0 +1,74 @@
+library(tidyverse)
+library(lubridate)
+library(exiftoolr)
+library(jpeg)
+install_exiftool()
+
+timelapse_folder_rename <- function(){
+
+  #grab filenames for folder we want to change
+  raw_filenames <- list.files("data/timelapse_raw", full.names = T)
+  file_list <- list.files(paste0(raw_filenames[1], "/"), full.names = T)
+  
+  if(is_empty(raw_filenames)){
+    print("No Folders to rename")
+  }else{
+get_site <- function(site_prompt){
+  while (TRUE) {
+    user_input <- readline(prompt = paste(site_prompt))
+    user_input <- tolower(user_input)
+    
+    sites <- c("tamasag", "legacy", "lincoln", "timberline", "prospect", "boxelder", "archery", "riverbluffs")
+    
+    if (user_input %in% sites) {
+      return(user_input)
+    } else {
+      cat("Invalid input. Please enter a site in the PWQN.\n")
+    }
+  }
+  
+}
+
+prompt_rename <- function(){
+  
+
+  # Read the fifth JPEG image (sometimes the first few are for set up)
+    img <- readJPEG(file_list[3])
+    
+    gg_image <- ggplot() +
+      annotation_raster(img, xmin = 0, xmax = 1, ymin = 0, ymax = 1)
+    
+    # Display the image using ggplot
+    print(gg_image)
+    # Ask to wait and then pause other text for 10 sec
+    print("Please Wait while picture loads")
+    Sys.sleep(10) 
+  site_choice_prompt <- 'What site does this photo belong to?  '
+  site_choice <- get_site(site_choice_prompt)
+  return(site_choice)
+}
+
+#run prompt rename (with get site nested inside)
+#User will be shown photo and asked for site name
+site <- prompt_rename()
+
+#grab metadata for first and last site photo in folder
+
+first_metadata <- exif_read(file_list[1])
+last_metadata <- exif_read(file_list[length(file_list)])
+
+# Extract start and end dates and format to YYYYMMDD
+start <- format(strptime(first_metadata$DateTimeOriginal, format = "%Y:%m:%d %H:%M:%S"),"%Y%m%d" )
+last <- format(strptime(last_metadata$DateTimeOriginal, format = "%Y:%m:%d %H:%M:%S"),"%Y%m%d" )
+#Get current folder name
+current_folder_name <- raw_filenames[1]
+#Create new folder name
+folder_rename <- paste0("data/timelapse_photos/", site, "_", start, "_", last)
+#Change the folder name and move to timelapse clean
+file.rename(current_folder_name, folder_rename)
+# Print folder rename to user
+cat("\n Folder renamed to ", folder_rename,"\n")
+}
+
+}
+

--- a/src/mWater_collate/download_pictures.R
+++ b/src/mWater_collate/download_pictures.R
@@ -1,10 +1,10 @@
-library(tidyverse)
+
 
 download_pictures <- function(){
   # Find all the downloaded pictures
   all_file_names <- list.files(path = "data/field_pics/", recursive = TRUE)
   #grab notes
-  sampling_photos <- all_notes%>%
+  sampling_photos <- all_notes_cleaned%>%
     #grab needed columns
     select(site, start_dt,photos_downloaded,upstream_pic,downstream_pic,clarity,filter_pic,other_pic,other_pic_descriptor)%>%
     mutate(
@@ -54,7 +54,7 @@ path <- "data/field_pics/"
 
 
   # loop thru dataset and download the photo ONLY if it is not yet downloaded and not NA
-  for (i in 1:length(sampling_photos$site)) {
+  for (i in 1:nrow(sampling_photos)) {
     if (!is.na(sampling_photos$upstream_downloaded[i]) && !sampling_photos$upstream_downloaded[i]) {
       download.file(sampling_photos$upstream_pic[i], destfile = paste0(path,sampling_photos$upstream_filename[i]))
     }
@@ -71,7 +71,7 @@ path <- "data/field_pics/"
   }
 
   #grab notes for sites with other pictures
-  other_photos <- all_notes%>%
+  other_photos <- all_notes_cleaned%>%
     #grab needed columns
     select(site, start_dt,other_pic,other_pic_descriptor)%>%
     #get rid of instances with no other pics
@@ -98,10 +98,10 @@ path <- "data/field_pics/"
            ))
 
   # loop thru dataset and download the photo ONLY if it is not yet downloaded and not NA
-  for (i in 1:length(other_photos$site)) {
+  for (i in 1:nrow(other_photos)) {
     if (!is.na(other_photos$other_downloaded[i]) && !other_photos$other_downloaded[i]) {
       download.file(other_photos$other_pic[i], destfile = paste0(path,other_photos$other_filename[i]))
     }}
 
-
+cat("All Available Pictures Downloaded")
 }

--- a/src/mWater_collate/download_pictures.R
+++ b/src/mWater_collate/download_pictures.R
@@ -1,0 +1,107 @@
+library(tidyverse)
+
+download_pictures <- function(){
+  # Find all the downloaded pictures
+  all_file_names <- list.files(path = "data/field_pics/", recursive = TRUE)
+  #grab notes
+  sampling_photos <- all_notes%>%
+    #grab needed columns
+    select(site, start_dt,photos_downloaded,upstream_pic,downstream_pic,clarity,filter_pic,other_pic,other_pic_descriptor)%>%
+    mutate(
+      #Date format for pictures
+      yyyymmdd = format(start_dt, "%Y%m%d"),
+      #create filenames ONLY if there is a URL associated with the site visit
+      upstream_filename = case_when(
+        !is.na(upstream_pic) ~ paste0(site, "_", yyyymmdd, "_upstream.jpg"),
+        TRUE ~ NA_character_
+      ),
+      downstream_filename = case_when(
+        !is.na(downstream_pic) ~ paste0(site, "_", yyyymmdd, "_downstream.jpg"),
+        TRUE ~ NA_character_
+      ),
+      clarity_filename = case_when(
+        !is.na(clarity) ~ paste0(site, "_", yyyymmdd, "_clarity.jpg"),
+        TRUE ~ NA_character_
+      ),
+      filter_filename = case_when(
+        !is.na(filter_pic) ~ paste0(site, "_", yyyymmdd, "_filter.jpg"),
+        TRUE ~ NA_character_
+      ),
+      # check to see if the photo is already downloaded to folder
+      upstream_downloaded = case_when(
+        is.na(upstream_filename) ~ NA,
+        upstream_filename %in% all_file_names ~ TRUE,
+        TRUE ~ FALSE
+      ),
+      clarity_downloaded = case_when(
+        is.na(clarity_filename) ~ NA,
+        clarity_filename %in% all_file_names ~ TRUE,
+        TRUE ~ FALSE
+      ),
+      filter_downloaded = case_when(
+        is.na(filter_filename) ~ NA,
+        filter_filename %in% all_file_names ~ TRUE,
+        TRUE ~ FALSE
+      ),
+      downstream_downloaded = case_when(
+        is.na(downstream_filename) ~ NA,
+        downstream_filename %in% all_file_names ~ TRUE,
+        TRUE ~ FALSE
+      )
+    )
+# basic path to field pics
+path <- "data/field_pics/"
+
+
+  # loop thru dataset and download the photo ONLY if it is not yet downloaded and not NA
+  for (i in 1:length(sampling_photos$site)) {
+    if (!is.na(sampling_photos$upstream_downloaded[i]) && !sampling_photos$upstream_downloaded[i]) {
+      download.file(sampling_photos$upstream_pic[i], destfile = paste0(path,sampling_photos$upstream_filename[i]))
+    }
+
+    if (!is.na(sampling_photos$downstream_downloaded[i]) && !sampling_photos$downstream_downloaded[i]) {
+      download.file(sampling_photos$downstream_pic[i], destfile = paste0(path, sampling_photos$downstream_filename[i]))
+    }
+    if (!is.na(sampling_photos$clarity_downloaded[i]) && !sampling_photos$clarity_downloaded[i]) {
+      download.file(sampling_photos$clarity[i], destfile = paste0(path, sampling_photos$clarity_filename[i]))
+    }
+    if (!is.na(sampling_photos$filter_downloaded[i]) && !sampling_photos$filter_downloaded[i]) {
+      download.file(sampling_photos$filter_pic[i], destfile = paste0(path, sampling_photos$filter_filename[i]))
+    }
+  }
+
+  #grab notes for sites with other pictures
+  other_photos <- all_notes%>%
+    #grab needed columns
+    select(site, start_dt,other_pic,other_pic_descriptor)%>%
+    #get rid of instances with no other pics
+    filter(!is.na(other_pic))%>%
+    mutate(
+      #Date format for pictures
+      yyyymmdd = format(start_dt, "%Y%m%d"),
+      # separate multiple URLs in other pic column
+      other_pic_sep = str_split(other_pic, "; "),
+      #seperate multiple descriptors in the descriptor column
+      other_descriptor_sep = str_split(other_pic_descriptor, ","))%>%
+    #for rows with multiple pictures, create a new row for each picture
+    unnest(cols = c(other_pic_sep, other_descriptor_sep))%>%
+    #remove excess columns and rename sep columns to match old columns
+    select(site, start_dt,yyyymmdd, other_pic = other_pic_sep, other_pic_descriptor = other_descriptor_sep)%>%
+    # make descriptor lower case and remove any spaces in the name
+    mutate(other_pic_descriptor = tolower(str_replace_all(other_pic_descriptor, " ", "")),
+           other_filename = case_when(!is.na(other_pic) ~ paste0(site, "_", yyyymmdd, "_", other_pic_descriptor, ".jpg")),
+           # Check to see if photo has already been downloaded
+           other_downloaded = case_when(
+             is.na(other_filename) ~ NA,
+             other_filename %in% all_file_names ~ TRUE,
+             TRUE ~ FALSE
+           ))
+
+  # loop thru dataset and download the photo ONLY if it is not yet downloaded and not NA
+  for (i in 1:length(other_photos$site)) {
+    if (!is.na(other_photos$other_downloaded[i]) && !other_photos$other_downloaded[i]) {
+      download.file(other_photos$other_pic[i], destfile = paste0(path,other_photos$other_filename[i]))
+    }}
+
+
+}

--- a/src/mWater_collate/files_missing.R
+++ b/src/mWater_collate/files_missing.R
@@ -1,0 +1,61 @@
+files_missing <- function(){
+  cal_reports_simple <- str_extract(list.files(path = "data/calibration_reports/"), ".*_\\d{8}" )
+  logs_simple <- str_extract(list.files(path = "data/sensor_data/2023", recursive = TRUE), "\\w+_\\d{8}_(vulink|troll)")
+
+  #grab sensor notes that have logs or cal reports that should be  downloaded
+  sensor_files <- sensor_notes%>%
+    filter(cal_report_collected|log_downloaded)%>%
+    select(site, crew, start_dt, cal_report_collected, cals_performed, log_downloaded, log1_type,log1_mmdd,  log2_type, log2_mmdd)%>%
+    mutate(# Create basis for calibration report name
+      # this will be used to check for calibration report in data files and then b
+      cal_report_name = case_when(cal_report_collected == TRUE ~ paste0(tolower(site), "_", format(start_dt, "%Y%m%d")),
+                                  cal_report_collected == NA ~ NA),
+      log1_mmdd = case_when(nchar(as.character(log1_mmdd)) == 3 ~ paste0("0",log1_mmdd),
+                            TRUE ~ as.character(log1_mmdd)),
+      log1_type = tolower(log1_type),
+      log2_type = tolower(log2_type),
+      log2_mmdd = case_when(nchar(as.character(log2_mmdd)) == 3 ~ paste0("0",log2_mmdd),
+                            TRUE ~ as.character(log2_mmdd)),
+      log1_user_error = case_when( is.na(log_downloaded)~ FALSE,
+                                   log_downloaded == FALSE ~ FALSE,
+                                   is.na(log1_mmdd) | is.na(log1_type) ~ TRUE,
+                                   TRUE ~ FALSE ),
+      log2_user_error = case_when(is.na(log_downloaded)~ FALSE,
+                                  log_downloaded == FALSE ~ FALSE,
+                                  is.na(log2_mmdd) & is.na(log2_type) ~ FALSE,
+                                  is.na(log2_mmdd) | is.na(log2_type) ~ TRUE,
+                                  TRUE ~ FALSE),
+      log1_name = case_when(!(is.na(log1_mmdd) | is.na(log1_type)) ~ paste0(site,"_",year(start_dt),log1_mmdd,
+                                                                            "_", format(start_dt, "%Y%m%d"), "_", log1_type),
+                            (is.na(log1_mmdd) | is.na(log1_type))  ~ NA),
+      log2_name = case_when(!(is.na(log2_mmdd) | is.na(log2_type)) ~ paste0(site,"_",year(start_dt),log2_mmdd,
+                                                                            "_", format(start_dt, "%Y%m%d"), "_", log2_type),
+                            (is.na(log2_mmdd) | is.na(log2_type))  ~ NA),
+      log_missing = case_when(
+        log1_name %nin% logs_simple | log2_name %nin% logs_simple ~ TRUE,
+        TRUE ~ FALSE
+      ),
+      cal_missing = case_when(
+        cal_report_name %nin% cal_reports_simple ~ TRUE,
+        TRUE ~ FALSE
+      )
+    )
+
+
+  for (i in 1:nrow(sensor_files)) {
+
+    #if log missing print out missing logs or cal reports
+    if(sensor_files$log_missing[i]){
+      cat("\nLog Missing: ", sensor_files$log1_name[i], " or ", sensor_files$log2_name[i], "\nContact: ", sensor_files$crew[i], "\n")
+
+    }
+    #if log missing print out missing logs or cal reports
+    if(sensor_files$cal_missing[i]){
+      cat("\nCal Missing: ", sensor_files$cal_report_name[i]," \nContact: ", sensor_files$crew[i], "\n")
+    }
+
+
+  }
+  cat("\nFile Check Complete")
+
+}

--- a/src/mWater_collate/mWater_pull_collate.Rmd
+++ b/src/mWater_collate/mWater_pull_collate.Rmd
@@ -1,0 +1,166 @@
+---
+title: "mWater_pull_collate"
+author: "Sam Struthers"
+date: "`r Sys.Date()`"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+library(tidyverse)
+
+#grab site metadata
+sampling_sites <- read_csv("data/water_sampling_sites.csv")
+# sort for
+upper_sites <- sampling_sites%>%
+  filter(watershed != "CLP  Mainstem-Fort Collins")%>%
+  mutate(site_code = tolower(site_code))
+```
+
+# API Pull and download raw sensor notes
+
+```{r}
+# 
+creds = yaml::read_yaml("src/mWater_collate/mWater_API.yml")
+api_url = as.character(creds["url"])
+rm(creds)
+#create raw download spreadsheet
+download.file(api_url, destfile = "data/mWater_raw_sensor_notes.csv")
+
+```
+
+
+# Tidying
+
+## ALL NOTES
+```{r}
+#read in file
+all_notes <- read_csv(file = "data/mWater_raw_sensor_notes.csv")%>%
+  mutate(
+    #start dt comes in UTC -> to MST
+    start_dt = with_tz(start_dt, tz = "America/Denver"),
+         date = as.Date(start_dt),
+         time_start = format(start_dt, "%H:%M"),
+    # If other is chose, make site == other response and make it lowercase     
+    site = ifelse(site == "Other (please specify)", tolower(site_other), site),
+    site = ifelse(site %in% upper_sites$site_code, toupper(site), site),
+         site_other = NULL,
+         #this part does not work yet
+         # (cant get rid of (please specify))
+         visit_type = ifelse(str_detect(visit_type, "Other"),
+                             str_replace(visit_type, "Other (please specify),", visit_type_other),
+                             visit_type),
+         #If other is chosen, make photos downloaded equal to response
+         photos_downloaded = ifelse(photos_downloaded == "Other (please specify)", photos_downloaded_other, photos_downloaded),
+         photos_downloaded_other = NULL, 
+         #Date/field season columns to match QAQC workflow
+         DT_round = floor_date(start_dt, "15 minutes"),
+         DT_join = as.character(DT_round),
+         field_season = year(DT_round),
+         last_site_visit = DT_round) %>%
+#arrange by most recent visit
+    arrange(DT_round)
+```
+
+
+## Sensor Notes
+
+```{r}
+#grab only notes where technician is interacting with sensor
+sensor_notes <- all_notes%>%
+  filter(grepl("Sensor",visit_type))%>%
+  select(-c(chla_volume_ml, vol_filtered_blank_dup, sample_collected,do_mgl,
+            cond_ms_cm, temp_c, upstream_pic, downstream_pic, clarity, other_pic, other_pic_descriptor))%>%
+  mutate(sonde_employed = case_when(is.na(sensor_change)  ~ 1,
+                                    sensor_change == "Pulled" ~ 0,
+                                    sensor_change %in% c("Swapped", "Deployed") ~ 1), 
+         # Create basis for calibration report name
+         # this will be used to check for calibration report in data files and then b
+         cal_report_name = case_when(cal_report_collected == TRUE ~ paste0(site, "_", format(start_dt, "%Y%m%d")),
+                                    cal_report_collected == NA ~ NA), 
+         log1_mmdd = case_when(nchar(as.character(log1_mmdd)) == 3 ~ paste0("0",log1_mmdd),
+                               TRUE ~ as.character(log1_mmdd)),
+         log1_type = tolower(log1_type),
+         log2_type = tolower(log2_type),
+         log2_mmdd = case_when(nchar(as.character(log2_mmdd)) == 3 ~ paste0("0",log2_mmdd),
+                               TRUE ~ as.character(log2_mmdd)),
+         log1_user_error = case_when( is.na(log_downloaded)~ FALSE,
+                                     log_downloaded == FALSE ~ FALSE,
+                                     is.na(log1_mmdd) | is.na(log1_type) ~ TRUE,
+                                TRUE ~ FALSE ),
+         log2_user_error = case_when(is.na(log_downloaded)~ FALSE,
+                                     log_downloaded == FALSE ~ FALSE,
+                                     is.na(log2_mmdd) | is.na(log2_type) ~ TRUE,
+                                TRUE ~ FALSE),
+         log1_name = case_when(!(is.na(log1_mmdd) | is.na(log1_type)) ~ paste0(site,"_",year(start_dt),log1_mmdd,
+                                                               "_", format(start_dt, "%Y%m%d"), "_", log1_type),
+                               (is.na(log1_mmdd) | is.na(log1_type))  ~ NA),
+         log2_name = case_when(!(is.na(log2_mmdd) | is.na(log2_type)) ~ paste0(site,"_",year(start_dt),log2_mmdd,
+                                                               "_", format(start_dt, "%Y%m%d"), "_", log2_type),
+                               (is.na(log2_mmdd) | is.na(log2_type))  ~ NA)
+        )%>%
+  arrange(desc(start_dt))%>%
+  nest(data =   c(cal_report_name, log1_name, log2_name, log1_user_error, log2_user_error, log1_mmdd,log1_type, log2_mmdd, log2_type))%>%
+  rename(log_cal_report_info = data)
+
+#unnest for csv
+sensor_notes_unnested <- sensor_notes%>%
+  unnest(log_cal_report_info)
+#write to CSV
+write_csv(sensor_notes_unnested, "data/mWater_sensor_field_notes.csv")
+
+```
+
+
+## Water sampling
+
+```{r}
+# create df of all water samples and save DT, handheld probe and chla volume data
+sampling_notes <- all_notes%>%
+  filter(grepl("Sampling",visit_type))%>% 
+  mutate(all_pics_taken = case_when(!is.na(downstream_pic)&!is.na(upstream_pic)&!is.na(clarity)&!is.na(filter_pic) ~ TRUE, TRUE ~ FALSE))%>%
+  select(site,crew, DT_round, date, time = time_start, sample_collected, chla_volume_ml, vol_filtered_blank_dup, do_mgl, cond_ms_cm, temp_c, visit_comments, all_pics_taken)
+
+# Distinguish BLANK and DUPLICATE values
+blanks_dups <- sampling_notes %>%
+  filter(grepl("DUPLICATE|BLANK", sample_collected)) %>%
+  mutate(sample_collected = ifelse(grepl("DUPLICATE", sample_collected), "DUPLICATE", "BLANK"), 
+         chla_volume_ml = vol_filtered_blank_dup, 
+         vol_filtered_blank_dup = NULL)
+
+# Add blank and duplicate values back to main
+sampling_notes <- sampling_notes%>%
+  mutate(sample_collected = gsub("DUPLICATE|BLANK| |,", "", sample_collected), 
+         vol_filtered_blank_dup = NULL)%>%
+  rbind(blanks_dups)%>%
+  arrange(DT_round, site)
+
+```
+
+### Save data for RMRS spreadsheet
+
+
+```{r}
+#FORMAT FOR RMRS Spreadsheet
+source("src/mWater_collate/sampling_spreadsheet_creator.R")
+#Site	SiteDescr	SiteLabel	Date SampleType
+sampling_spreadsheet_creator("2023-10-16")
+```
+
+## Photos
+
+```{r}
+# This downloads upstream, downstream, clarity and filter pictures
+
+source("src/mWater_collate/download_pictures.R")
+  
+#RUN TO DOWNLOAD NEW PICTURES
+
+download_pictures()
+        
+
+```
+
+
+```
+

--- a/src/mWater_collate/mWater_pull_collate.Rmd
+++ b/src/mWater_collate/mWater_pull_collate.Rmd
@@ -11,38 +11,53 @@ library(tidyverse)
 
 #grab site metadata
 sampling_sites <- read_csv("data/water_sampling_sites.csv")
-# sort for
+# sort for sites in upper network (ie. acronyms rather than street names)
 upper_sites <- sampling_sites%>%
   filter(watershed != "CLP  Mainstem-Fort Collins")%>%
+  #this is to help match with user input
   mutate(site_code = tolower(site_code))
+
+`%nin%` = Negate(`%in%`)
 ```
 
-# API Pull and download raw sensor notes
+# API Pull of mWater submitted notes
 
 ```{r}
-# 
+# Grab API url from yml
+# Contact Sam Struthers if you need access
 creds = yaml::read_yaml("src/mWater_collate/mWater_API.yml")
 api_url = as.character(creds["url"])
-rm(creds)
-#create raw download spreadsheet
-download.file(api_url, destfile = "data/mWater_raw_sensor_notes.csv")
 
+
+#read in datasheet from mWater portal API
+all_notes <- read_csv(url(api_url))
+
+rm(creds, api_url)
 ```
 
+# Tidying for downstream use
 
-# Tidying
+This is basic tidying of data set to:
 
-## ALL NOTES
+-    correct datetime from UTC to Denver time
+
+-   correct columns where Other input is allowed (Site, visit type, photos downloaded)
+
+-   Add rounded date time
+
 ```{r}
-#read in file
-all_notes <- read_csv(file = "data/mWater_raw_sensor_notes.csv")%>%
+
+all_notes_cleaned <- all_notes%>%
   mutate(
-    #start dt comes in UTC -> to MST
-    start_dt = with_tz(start_dt, tz = "America/Denver"),
+    #start and end dt comes in as UTC -> to MST
+        start_dt = with_tz(ymd_hms(start_dt), tz = "America/Denver"),
+        end_dt = with_tz(ymd_hms(end_dt), tz = "America/Denver"),
          date = as.Date(start_dt),
          time_start = format(start_dt, "%H:%M"),
-    # If other is chose, make site == other response and make it lowercase     
-    site = ifelse(site == "Other (please specify)", tolower(site_other), site),
+        
+    # If other is chosen, make site == other response      
+    site = ifelse(site == "Other (please specify)", tolower(str_replace_all(site_other, " ", "")), site),
+    #correct names if it is in our upper sites (acronyms)
     site = ifelse(site %in% upper_sites$site_code, toupper(site), site),
          site_other = NULL,
          #this part does not work yet
@@ -53,114 +68,88 @@ all_notes <- read_csv(file = "data/mWater_raw_sensor_notes.csv")%>%
          #If other is chosen, make photos downloaded equal to response
          photos_downloaded = ifelse(photos_downloaded == "Other (please specify)", photos_downloaded_other, photos_downloaded),
          photos_downloaded_other = NULL, 
-         #Date/field season columns to match QAQC workflow
-         DT_round = floor_date(start_dt, "15 minutes"),
-         DT_join = as.character(DT_round),
-         field_season = year(DT_round),
-         last_site_visit = DT_round) %>%
+         #Rounded start date time
+         DT_round = floor_date(start_dt, "15 minutes")) %>%
 #arrange by most recent visit
     arrange(DT_round)
 ```
 
+# Sensor Notes
 
-## Sensor Notes
+These are the notes that will be added to the QAQC workflow notes Most of the code in this chunk is to get the df to match the one in the QAQC workflow It can be saved as a CSV or pulled directly into QAQC workflow
 
 ```{r}
 #grab only notes where technician is interacting with sensor
-sensor_notes <- all_notes%>%
+
+sensor_notes <- all_notes_cleaned%>%
   filter(grepl("Sensor",visit_type))%>%
-  select(-c(chla_volume_ml, vol_filtered_blank_dup, sample_collected,do_mgl,
-            cond_ms_cm, temp_c, upstream_pic, downstream_pic, clarity, other_pic, other_pic_descriptor))%>%
+  select(-c(visit_type_other, chla_volume_ml, vol_filtered_blank_dup, sample_collected,do_mgl,
+            cond_ms_cm, temp_c, upstream_pic, downstream_pic, clarity, filter_pic, other_pic, other_pic_descriptor))%>%
+  # determining sonde employed status based on sensor_change 
   mutate(sonde_employed = case_when(is.na(sensor_change)  ~ 1,
                                     sensor_change == "Pulled" ~ 0,
-                                    sensor_change %in% c("Swapped", "Deployed") ~ 1), 
-         # Create basis for calibration report name
-         # this will be used to check for calibration report in data files and then b
-         cal_report_name = case_when(cal_report_collected == TRUE ~ paste0(site, "_", format(start_dt, "%Y%m%d")),
-                                    cal_report_collected == NA ~ NA), 
-         log1_mmdd = case_when(nchar(as.character(log1_mmdd)) == 3 ~ paste0("0",log1_mmdd),
-                               TRUE ~ as.character(log1_mmdd)),
-         log1_type = tolower(log1_type),
-         log2_type = tolower(log2_type),
-         log2_mmdd = case_when(nchar(as.character(log2_mmdd)) == 3 ~ paste0("0",log2_mmdd),
-                               TRUE ~ as.character(log2_mmdd)),
-         log1_user_error = case_when( is.na(log_downloaded)~ FALSE,
-                                     log_downloaded == FALSE ~ FALSE,
-                                     is.na(log1_mmdd) | is.na(log1_type) ~ TRUE,
-                                TRUE ~ FALSE ),
-         log2_user_error = case_when(is.na(log_downloaded)~ FALSE,
-                                     log_downloaded == FALSE ~ FALSE,
-                                     is.na(log2_mmdd) | is.na(log2_type) ~ TRUE,
-                                TRUE ~ FALSE),
-         log1_name = case_when(!(is.na(log1_mmdd) | is.na(log1_type)) ~ paste0(site,"_",year(start_dt),log1_mmdd,
-                                                               "_", format(start_dt, "%Y%m%d"), "_", log1_type),
-                               (is.na(log1_mmdd) | is.na(log1_type))  ~ NA),
-         log2_name = case_when(!(is.na(log2_mmdd) | is.na(log2_type)) ~ paste0(site,"_",year(start_dt),log2_mmdd,
-                                                               "_", format(start_dt, "%Y%m%d"), "_", log2_type),
-                               (is.na(log2_mmdd) | is.na(log2_type))  ~ NA)
-        )%>%
-  arrange(desc(start_dt))%>%
-  nest(data =   c(cal_report_name, log1_name, log2_name, log1_user_error, log2_user_error, log1_mmdd,log1_type, log2_mmdd, log2_type))%>%
-  rename(log_cal_report_info = data)
-
-#unnest for csv
-sensor_notes_unnested <- sensor_notes%>%
-  unnest(log_cal_report_info)
+                                    sensor_change %in% c("Swapped", "Deployed") ~ 1),
+         #Date/field season columns to match QAQC workflow
+         DT_join = as.character(DT_round),
+         field_season = year(DT_round),
+         last_site_visit = DT_round
+  )%>%
+  arrange(desc(start_dt))
+         
 #write to CSV
-write_csv(sensor_notes_unnested, "data/mWater_sensor_field_notes.csv")
+write_csv(sensor_notes, "data/mWater_sensor_field_notes.csv")
 
 ```
 
+## Determining uploads
 
-## Water sampling
+This function looks at the user inputs for calibration report collect and logs collected. Based on these inputs, it looks at all the uploaded logs or calibration reports and will print out what logs are missing and who to contact to get those files uploaded.
 
 ```{r}
-# create df of all water samples and save DT, handheld probe and chla volume data
-sampling_notes <- all_notes%>%
-  filter(grepl("Sampling",visit_type))%>% 
-  mutate(all_pics_taken = case_when(!is.na(downstream_pic)&!is.na(upstream_pic)&!is.na(clarity)&!is.na(filter_pic) ~ TRUE, TRUE ~ FALSE))%>%
-  select(site,crew, DT_round, date, time = time_start, sample_collected, chla_volume_ml, vol_filtered_blank_dup, do_mgl, cond_ms_cm, temp_c, visit_comments, all_pics_taken)
 
-# Distinguish BLANK and DUPLICATE values
-blanks_dups <- sampling_notes %>%
-  filter(grepl("DUPLICATE|BLANK", sample_collected)) %>%
-  mutate(sample_collected = ifelse(grepl("DUPLICATE", sample_collected), "DUPLICATE", "BLANK"), 
-         chla_volume_ml = vol_filtered_blank_dup, 
-         vol_filtered_blank_dup = NULL)
+source("src/mWater_collate/files_missing.R")
 
-# Add blank and duplicate values back to main
-sampling_notes <- sampling_notes%>%
-  mutate(sample_collected = gsub("DUPLICATE|BLANK| |,", "", sample_collected), 
-         vol_filtered_blank_dup = NULL)%>%
-  rbind(blanks_dups)%>%
-  arrange(DT_round, site)
+files_missing()
 
 ```
 
-### Save data for RMRS spreadsheet
+## Water Sampling Data:
 
+Goal:
+
+-   Save data in the correct format for RMRS spreadsheet
+
+-   Save all water sampling probe values in a spreadsheet
 
 ```{r}
-#FORMAT FOR RMRS Spreadsheet
+#source function
 source("src/mWater_collate/sampling_spreadsheet_creator.R")
-#Site	SiteDescr	SiteLabel	Date SampleType
-sampling_spreadsheet_creator("2023-10-16")
+# To get the RMRS style data for a specfic date of sampling, 
+# Input the date of interest in sampling_spreadsheet_creator
+sampling_spreadsheet_creator(date_oi = "2023-10-16")
+
+# To get all the water sampling data and save to CSV in sampling notes
+# This also returns the df sampling_notes in case you want to review in R
+sampling_spreadsheet_creator(all_dates = TRUE)
 ```
 
 ## Photos
 
-```{r}
-# This downloads upstream, downstream, clarity and filter pictures
+Goal:
 
+-   Download all user created photos ( upstream, downstream, clarity, filter and other pictures)
+
+-   Label according to site, date, description in the format site_YYYYMMDD_descriptor.jpg
+
+-   Only download photos which have not yet been downloaded
+
+```{r}
 source("src/mWater_collate/download_pictures.R")
   
 #RUN TO DOWNLOAD NEW PICTURES
+# It takes about 2-5 minutes to download ~25-50 photos
 
 download_pictures()
         
 
 ```
-
-
-```
-

--- a/src/mWater_collate/sampling_spreadsheet_creator.R
+++ b/src/mWater_collate/sampling_spreadsheet_creator.R
@@ -1,21 +1,60 @@
-sampling_spreadsheet_creator <- function(date_oi = "2023-10-16" ){
+sampling_spreadsheet_creator <- function(date_oi = "2023-10-16", all_dates = FALSE ){
 
   #pull in site meta data
   site_meta <- read_csv("data/water_sampling_sites.csv")%>%
     select(site = site_code, Site_Name, site_label_rmrs)
-#grab desired date
-  date_oi_clean <- as.Date(date_oi)
-# filter sampling notes df by desired date
-  samples_of_day <- filter(sampling_notes,date == date_oi_clean )%>%
+
+  # create df of all water samples and save DT, handheld probe and chla volume data
+  sampling_notes <- all_notes_cleaned%>%
+    filter(grepl("Sampling",visit_type))%>%
+    mutate(all_pics_taken = case_when(!is.na(downstream_pic)&!is.na(upstream_pic)&!is.na(clarity)&!is.na(filter_pic) ~ TRUE, TRUE ~ FALSE))%>%
+    select(site,crew, DT_round, date, time = time_start, sample_collected, chla_volume_ml, vol_filtered_blank_dup, do_mgl, cond_ms_cm, temp_c, visit_comments, all_pics_taken)
+
+  # Distinguish BLANK and DUPLICATE values
+  blanks_dups <- sampling_notes %>%
+    #find all values that have blank or dup
+    filter(grepl("DUPLICATE|BLANK", sample_collected)) %>%
+    # change sample collected to match BLANK/DUP
+    mutate(sample_collected = ifelse(grepl("DUPLICATE", sample_collected), "DUPLICATE", "BLANK"),
+           # Volume filtered blank dup becomes chla volume
+           chla_volume_ml = vol_filtered_blank_dup,
+           #drop vol_filtered_blank/dup
+           vol_filtered_blank_dup = NULL)
+
+  # Add blank and duplicate values back to main
+  sampling_notes <- sampling_notes%>%
+    #get rid of blank/dup in sample collcected
+    mutate(sample_collected = gsub("DUPLICATE|BLANK| |,", "", sample_collected),
+           #drop vol_filtered_blank/dup
+           vol_filtered_blank_dup = NULL)%>%
+    #bring in blank and dup rows
+    rbind(blanks_dups)%>%
+    #arrange by datetime and site (Blanks and dups go second)
+    arrange(DT_round, site)%>%
     # join with RMRS friendly metadata
-    left_join(site_meta, by = "site")%>%
-    #match date to RMRS style
-    mutate(Date = format(date, "%d-%b-%y"),
-           #create SiteDescr column for RMRS sheet
-           SiteDescr = paste0(site, "_",format(date, "%m%d%y")))%>%
-    # select only the needed columns, saved in the correct order and fix column names
-    select(Site = site_label_rmrs ,SiteDescr, SiteLabel = site, Date, SampleType = sample_collected,
-           time, do_mgl, cond_ms_cm, temp_c, notes = visit_comments  )
-# write to csv
-  write_csv(x = samples_of_day, file = paste0("data/sampling_notes/samples_of_",date_oi,".csv" ))
+    left_join(site_meta, by = "site")
+
+
+
+ if (all_dates == TRUE) {
+
+   # write to csv
+   write_csv(x = sampling_notes, file = paste0("data/sampling_notes/all_samples_as_of_",as.character(Sys.Date()),".csv" ))
+ }else{
+   #grab desired date
+   date_oi_clean <- as.Date(date_oi)
+   # filter sampling notes df by desired date
+   samples_of_day <- filter(sampling_notes,date == date_oi_clean )%>%
+     #match date to RMRS style
+     mutate(Date = format(date, "%d-%b-%y"),
+            #create SiteDescr column for RMRS sheet
+            SiteDescr = paste0(site, "_",format(date, "%m%d%y")))%>%
+     # select only the needed columns, saved in the correct order and fix column names
+     select(Site = site_label_rmrs ,SiteDescr, SiteLabel = site, Date, SampleType = sample_collected,
+            time, do_mgl, cond_ms_cm, temp_c, notes = visit_comments  )
+   # write to csv
+   write_csv(x = samples_of_day, file = paste0("data/sampling_notes/samples_of_",date_oi,".csv" ))
+ }
 }
+
+

--- a/src/mWater_collate/sampling_spreadsheet_creator.R
+++ b/src/mWater_collate/sampling_spreadsheet_creator.R
@@ -1,0 +1,21 @@
+sampling_spreadsheet_creator <- function(date_oi = "2023-10-16" ){
+
+  #pull in site meta data
+  site_meta <- read_csv("data/water_sampling_sites.csv")%>%
+    select(site = site_code, Site_Name, site_label_rmrs)
+#grab desired date
+  date_oi_clean <- as.Date(date_oi)
+# filter sampling notes df by desired date
+  samples_of_day <- filter(sampling_notes,date == date_oi_clean )%>%
+    # join with RMRS friendly metadata
+    left_join(site_meta, by = "site")%>%
+    #match date to RMRS style
+    mutate(Date = format(date, "%d-%b-%y"),
+           #create SiteDescr column for RMRS sheet
+           SiteDescr = paste0(site, "_",format(date, "%m%d%y")))%>%
+    # select only the needed columns, saved in the correct order and fix column names
+    select(Site = site_label_rmrs ,SiteDescr, SiteLabel = site, Date, SampleType = sample_collected,
+           time, do_mgl, cond_ms_cm, temp_c, notes = visit_comments  )
+# write to csv
+  write_csv(x = samples_of_day, file = paste0("data/sampling_notes/samples_of_",date_oi,".csv" ))
+}


### PR DESCRIPTION
mWater is a survey platform used by CU folks to record field note visits. Data is stored in a datagrid associated with a survey on the mWater portal. These data can be downloaded using an API url (mWater api yml)
This PR has three main files which all live in the folder `mWater_collate`:
- `mWater_pull_collate.rmd`: main file which pulls data from mWater API and breaks it into three main sections: all_notes, sensor_notes, sampling_notes. 

Dataframes: All notes is everything submitted, sensor_notes is only visits where sensor was interacted with, sampling notes is when water sampling occured.  

Actions: save sensor notes to csv in data folder this is how we can maintain a backup of the data from mWater. This code also uses the photo_download and sampling spreadsheet creator functions (described below)
- `photo_downloader.R`: grabs all the download urls from the all notes sheet and will download+rename all the photos uploaded to mWater. It should not download any photos if they have already been downloaded
- `sampling_spreadsheet_creator.R`: formats a days worth of water sampling data to match RMRS formatting. This is mainly a tool that I will use after a field day to speed up sample input and make sure I don't create any typos in the RMRS masterfile. 

Review Requested:
- I will send you the API yml. Please test to make sure the whole pipeline works by running all the chunks (keeping in mind that photo downloader wont do anything since I already downloaded the photos)
- The code is not very concise, especially photo downloader so any suggestions on that would be helpful
- Check to make sure I mimic'ed the existing structure of our field notes in QAQC pipeline (start_dt, round_dt, sensor employed, etc)
- general notes on conciseness of rmd file and any sections that seem confusing