### PR TITLE
modify slope thresholds

### DIFF
--- a/src/qaqc/download_and_flag_fxns/make_threshold_table.R
+++ b/src/qaqc/download_and_flag_fxns/make_threshold_table.R
@@ -1,5 +1,21 @@
 make_threshold_table <- function(df){
 
+  slope_down <- df %>%
+    # REMOVE DATA WE KNOW TO BE ERRONEOUS:
+    add_malfunction_flag() %>%
+    filter(is.na(flag)) %>%
+    group_by(season) %>%
+    filter(slope_behind < 0) %>%
+    quantile(slope_behind, 0.01, na.rm = TRUE)
+
+  slope_up <- df %>%
+    # REMOVE DATA WE KNOW TO BE ERRONEOUS:
+    add_malfunction_flag() %>%
+    filter(is.na(flag)) %>%
+    group_by(season) %>%
+    filter(slope_behind > 0) %>%
+    quantile(slope_behind, 0.99, na.rm = TRUE)
+
   good_data_stats <- df %>%
     # REMOVE DATA WE KNOW TO BE ERRONEOUS:
     add_malfunction_flag() %>%
@@ -7,8 +23,8 @@ make_threshold_table <- function(df){
     group_by(season) %>%
     mutate(f01 = quantile(mean, 0.01, na.rm = TRUE),
            f99 = quantile(mean, 0.99, na.rm = TRUE),
-           f_slope_behind_01 = quantile(slope_behind, 0.01, na.rm = TRUE),
-           f_slope_behind_99 = quantile(slope_behind, 0.99, na.rm = TRUE)) %>%
+           f_slope_behind_01 = slope_down, #quantile(slope_behind, 0.01, na.rm = TRUE),
+           f_slope_behind_99 = slope_up) %>% #quantile(slope_behind, 0.99, na.rm = TRUE)) %>%
     # THEN, GET STANDARD DEVIATION OF ONLYYYY VALUES WITHIN THE 1-99th PERCENTILE OF THAT GOOD DATA:
     filter(mean > f01 & mean < f99) %>%
     # SD is the ONLY statistic that uses this winnowed-down data set in its development.
@@ -23,4 +39,4 @@ make_threshold_table <- function(df){
 
   return(good_data_stats)
 
-  }
+}


### PR DESCRIPTION
This PR modifies our slope thresholds by first parsing the positive and negative slope values out and grabbing the percentiles from those split-up ranges. I am hopeful this will make the slope function way less greedy, since it will be identifying more extreme values only.