### PR TITLE
Fixing add_thresholds_line issue with missing file and small tweak to plotter app

### DIFF
--- a/operations/raw_data_plotter.R
+++ b/operations/raw_data_plotter.R
@@ -16,8 +16,8 @@ ui <- fluidPage(
     sidebarPanel(
       # Allows user to select sites
       selectInput("selected_site", "Select Site(s)",
-                  choices = c("joei", "cbri", "chd", "pfal", "sfm", "lbea", "penn", "pbd", "lincoln", "timberline virridy", "timberline",
-                              "prospect virridy", "prospect", "archery virridy", "archery", "boxcreek", "springcreek"),
+                  choices = c("joei", "cbri", "chd", "pfal", "sfm", "lbea", "penn", "pbd","tamasag","legacy", "lincoln", "timberline virridy", "timberline",
+                              "prospect virridy", "prospect","boxelder",  "archery virridy", "archery", "boxcreek", "springcreek", "river bluffs"),
                   selected = "lincoln", multiple = TRUE),
       # User to select parameters
       selectInput("selected_param", "Select Parameter(s)",

--- a/src/add_threshold_lines.R
+++ b/src/add_threshold_lines.R
@@ -3,9 +3,14 @@ add_threshold_lines <- function(plot, plot_data, site_arg, parameter_arg) {
   # pull in threshold data (i don't like that I do this everytime the function is run)
   real_thresholds <- read_csv("data/qaqc/realistic_thresholds.csv", show_col_types = FALSE) %>%
     filter(parameter == parameter_arg)
-  sensor_thresholds <- read_csv("data/qaqc/sensor_spec_thresholds.csv", show_col_types = FALSE) %>%
-    filter(parameter == parameter_arg)
-  seasonal_thresholds <- bind_rows(read_csv('data/qaqc/seasonal_thresholds.csv', show_col_type = FALSE), read_csv('data/qaqc/seasonal_thresholds_virridy.csv', show_col_types = FALSE)) %>%
+
+  sensor_thresholds <- yaml::read_yaml("data/qaqc/sensor_spec_thresholds.yml")[[parameter_arg]]%>% #filter for parameter_arg
+    #turn into tibble with min/max
+    bind_rows()
+
+  seasonal_thresholds <- read_csv('data/qaqc/seasonal_thresholds_virridy.csv', show_col_types = FALSE) %>%
+    #to do: Check to make sure seasonal thresholds csv is not necessary
+    #bind_rows(read_csv('data/qaqc/seasonal_thresholds.csv', show_col_type = FALSE),
     distinct(site, parameter, season, .keep_all = TRUE) %>%
     #read_csv("data/qaqc/seasonal_thresholds_virridy.csv", show_col_types = FALSE) %>%
     filter(parameter == parameter_arg,
@@ -143,7 +148,7 @@ add_threshold_lines <- function(plot, plot_data, site_arg, parameter_arg) {
       }
 
       # sensor thresholds
-      sensor_thresholds_quantiles <- unname(quantile(c(sensor_thresholds$mix, sensor_thresholds$max), c(0.1, 0.9)))
+      sensor_thresholds_quantiles <- unname(quantile(c(sensor_thresholds$min, sensor_thresholds$max), c(0.1, 0.9)))
 
       # if ((min(site_data$mean, na.rm = TRUE) <= sensor_thresholds_quantiles[1])) {
       #   plot <- plot +
@@ -204,7 +209,7 @@ add_threshold_lines <- function(plot, plot_data, site_arg, parameter_arg) {
       }
 
       # sensor thresholds
-      sensor_thresholds_quantiles <- unname(quantile(c(sensor_thresholds$mix, sensor_thresholds$max), c(0.1, 0.9)))
+      sensor_thresholds_quantiles <- unname(quantile(c(sensor_thresholds$min, sensor_thresholds$max), c(0.1, 0.9)))
 
       # if (min(site_data$mean, na.rm = TRUE) <= sensor_thresholds_quantiles[1]) {
       #   plot <- plot +


### PR DESCRIPTION
After 'data/qaqc/sensor_spec_thresholds.csv' got deleted, `add_threshold_lines` was no longer working. Edited these lines to open the equivalent yaml file. Also fixed small typo (mix vs min) later on. Worked on my end after the change. 

 I also changed line 11 to only look at the virridy seasonal thresholds.csv, as @kathryn-willi  mentioned earlier this AM. 
 
 Added the remaining sites (tamasag, legacy, boxelder, river bluffs) to the shiny app so we just have one shiny app for viewing raw data from all sites