### PR TITLE
File path call updates

### DIFF
--- a/src/clean_directories.R
+++ b/src/clean_directories.R
@@ -1,4 +1,5 @@
 clean_directories <- function() {
+
   pre_dir_path <- pre_verification_path
   int_dir_path <- intermediary_path
   ver_dir_path <- verified_path
@@ -11,7 +12,7 @@ clean_directories <- function() {
   # keep if not in Verified Directory, else if in Verified Directory delete from this Directory
   for (i in pre_dir_names) {
     if (length(ver_dir_names) != 0 & i %in% ver_dir_names) {
-      file.remove(paste0(pre_dir_path, i))
+      file.remove(here(pre_dir_path, i))
       cat("removed file ", i, " from ",  pre_dir_path, "\n")
     } else {
       next
@@ -21,12 +22,12 @@ clean_directories <- function() {
   # Intermediary Directory
   # keep if skips in the data OR any(!is_verified), else move to Verified Directory
   for (i in int_dir_names) {
-    df <- readRDS(paste0(int_dir_path, i))
+    df <- read_rds(here(int_dir_path, i))
     if (any(df$verification_status == 'SKIP') | any(!df$is_verified)) {
       next
     } else if (all(df$verification_status != 'SKIP') & all(df$is_verified)) {
-      source_path <- paste0(int_dir_path, i)
-      destination_path <- paste0(ver_dir_path, i)
+      source_path <- here(int_dir_path, i)
+      destination_path <- here(ver_dir_path, i)
       file.copy(source_path, destination_path, overwrite = TRUE)
       file.remove(source_path)
       cat("moved file ", i, " from ", int_dir_path, "to", ver_dir_path, "\n")
@@ -36,7 +37,7 @@ clean_directories <- function() {
   # Verified Directory
   # final destination for data, check that the data that is here should be here
   for (i in ver_dir_names) {
-    df <- readRDS(paste0(ver_dir_path, i))
+    df <- read_rds(here(ver_dir_path, i))
     if (any(df$verification_status == 'SKIP') | any(!df$is_verified)) {
       cat(i, "should not be in verified directory\n")
       stop("THERE IS DATA WITH SKIPS OR NON-VERIFIED DATA IN THE VERIFIED DIRECTORY")

--- a/src/save_intermediary_dir.R
+++ b/src/save_intermediary_dir.R
@@ -7,14 +7,14 @@ save_intermediary_dir <- function(updated_df, df_name) {
       user_input <- tolower(user_input)
 
       if (user_input == "yes") {
-        saveRDS(updated_df, paste0(intermediary_path, df_name))
+        saveRDS(updated_df, here(intermediary_path, df_name))
         break
       }
 
       if (user_input == "no") {
-        working_data <<- set_names(map(list.files(intermediary_path, full.names = TRUE), readRDS), list.files(intermediary_path))
+        working_data <<- set_names(map(list.files(intermediary_path, full.names = TRUE), read_rds), list.files(intermediary_path))
         updated_site_param_df <<- working_data[[site_param_name]] # working dir df
-        saveRDS(updated_site_param_df, paste0(intermediary_path, df_name))
+        saveRDS(updated_site_param_df, here(intermediary_path, df_name))
         break
       }
 
@@ -32,7 +32,7 @@ save_intermediary_dir <- function(updated_df, df_name) {
       user_input <- tolower(user_input)
 
       if (user_input == "yes") {
-        saveRDS(updated_df, paste0(intermediary_path, df_name))
+        saveRDS(updated_df, here(intermediary_path, df_name))
         break
       }
 
@@ -47,5 +47,5 @@ save_intermediary_dir <- function(updated_df, df_name) {
     }
   }
 
-  saveRDS(updated_df, paste0(intermediary_path, df_name))
+  saveRDS(updated_df, here(intermediary_path, df_name))
 }

--- a/virridy/verification_workflow/0_verification_preprocessing.Rmd
+++ b/virridy/verification_workflow/0_verification_preprocessing.Rmd
@@ -11,7 +11,7 @@ verified_path <- here("data", "virridy_verification", "verified_directory")
 ```
 
 ```{r}
-flagged_data <- readRDS(here("data","virridy_verification","all_data_flagged_complete.RDS"))
+flagged_data <- read_rds(here("data","virridy_verification","all_data_flagged_complete.RDS"))
 
 pre_processed_data <- map(.x = flagged_data, \(x)
   x %>% 
@@ -31,7 +31,7 @@ pre_processed_data <- map(.x = flagged_data, \(x)
 Now we will move the pre-processed flagged data into the pending review directory
 ```{r}
 iwalk(pre_processed_data, \(x, idx)
-      saveRDS(x, paste0(all_path, idx))
+      saveRDS(x, here(all_path, idx))
       )
 
 R.utils::copyDirectory(all_path, pre_verification_path)

--- a/virridy/verification_workflow/1_verification_setup.Rmd
+++ b/virridy/verification_workflow/1_verification_setup.Rmd
@@ -8,29 +8,29 @@ library(tidyverse)
 library(ggpubr)
 library(here)
 
-# set data directory paths
-all_path <- here("data", "virridy_verification", "all_data_directory")
-pre_verification_path <- here("data", "virridy_verification", "pre_verification_directory")
-intermediary_path <- here("data", "virridy_verification", "intermediary_directory")
-verified_path <- here("data", "virridy_verification", "verified_directory")
-
 # set function directory paths
-fxn_path <- "src/"
+fxn_path <- here("src")
 
 # Source functions
 invisible(map(
   list.files(fxn_path, pattern = "*.R", full.names = TRUE),
   ~ source(.x, echo = FALSE)
 ))
+
+# set data directory paths
+all_path <- here("data", "virridy_verification", "all_data_directory")
+pre_verification_path <- here("data", "virridy_verification", "pre_verification_directory")
+intermediary_path <- here("data", "virridy_verification", "intermediary_directory")
+verified_path <- here("data", "virridy_verification", "verified_directory")
   
 # Load all flagged data
-all_data <- set_names(map(list.files(all_path, full.names = TRUE), readRDS), list.files(all_path))
+all_data <- set_names(map(list.files(all_path, full.names = TRUE), read_rds), list.files(all_path))
 
 # Load all intermediary data
-intermediary_data <- set_names(map(list.files(intermediary_path, full.names = TRUE), readRDS), list.files(intermediary_path))
+intermediary_data <- set_names(map(list.files(intermediary_path, full.names = TRUE), read_rds), list.files(intermediary_path))
 
 # Load all verified data
-verified_data <- set_names(map(list.files(verified_path, full.names = TRUE), readRDS), list.files(verified_path))
+verified_data <- set_names(map(list.files(verified_path, full.names = TRUE), read_rds), list.files(verified_path))
 ```
 
 ```{r working data selection}
@@ -42,7 +42,7 @@ get_working_data_decision()
 network <- "virridy"
 # Set the site and parameter to verify
 site <- "archery"
-parameter <- "Temperature"
+parameter <- "Chl-a Fluorescence"
 ```
 
 ```{r set the site-param df to update}
@@ -71,7 +71,4 @@ weekly_plot_objects <- generate_initial_weekly_plots(
   flag_arg = NULL
 )
 QUIT <- FALSE
-
-# Subset weekly plot objects (for testing)
-# weekly_plot_objects <- tail(weekly_plot_objects, 4)
 ```

--- a/virridy/verification_workflow/2_verification_method.R
+++ b/virridy/verification_workflow/2_verification_method.R
@@ -37,7 +37,7 @@ for (i in weekly_plot_objects) {
       rows_update(update, by = "DT_join")
 
     # update the saved data in the intermediary dir
-    saveRDS(object = updated_site_param_df, file = paste0(intermediary_path, site_param_name))
+    saveRDS(object = updated_site_param_df, file = here(intermediary_path, site_param_name))
 
     graphics.off()
     gc()
@@ -50,7 +50,9 @@ for (i in weekly_plot_objects) {
 QUIT <- FALSE
 
 # check data
-updated_df <- readRDS(paste0(intermediary_path, site_param_name))
+updated_df <- read_rds(here(intermediary_path, site_param_name)) %>%
+  select(DT_join, site, parameter, mean, mean_verified, is_verified, verification_status) %>%
+  filter(is_verified)
 
 # clean the directories
 clean_directories()


### PR DESCRIPTION
These updates are related to how we call the file paths in the verification workflow to make them more robust across OS's. 
- I use `here()` instead of string concatenation to make those calls more robust across OS's. 
- I replace `readRDS()` with `read_rds()` to make pulling in data more robust across OS's.
- Note that I did not update `saveRDS()` with `write_rds()`. This made the row updates slower and error out. Something to look into in the future. `saveRDS` works fine still.

@kathryn-willi and @SamStruthers -- If y'all could make sure that this doesn't break things on your end and behaves as expected that would be great.

@ecogub -- Nick, if you could test to see if this works at all on your windows machine that would be great. lmk if you can't so I can seek out a window machine to test on. 