### PR TITLE
Implement Sensor Calibration Workflow Functions

### DIFF
--- a/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
+++ b/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
@@ -245,7 +245,7 @@ while maintaining the overall automated workflow for standard cases.
 
 ## The `back_calibrate()` Function
 
-The `back_calibrate()` function serves as the orchestrator for the entire calibration 
+The `cal_back_calibrate()` function serves as the orchestrator for the entire calibration 
 process within each chunk. It automatically determines the appropriate calibration 
 workflow based on the sensor parameter type. Standard sensors (Chlorophyll-a, 
 FDOM, ORP, Pressure, Specific Conductivity, RDO) follow a five-step process 

--- a/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
+++ b/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
@@ -3,10 +3,16 @@ title: "fixing_calibrations"
 output: html_document
 ---
 
-```{r}
-# Initialize Environment
-# source(file.path("scratch","data_tidying","sensor_calibration","R","init_sub_env","init.R"))
+# Introduction
 
+This vignette demonstrates the complete workflow for back-calibrating water 
+quality sensor data using calibration information extracted from HTML calibration 
+files. The process corrects sensor drift and applies temporal interpolation 
+between calibrations to produce accurate time series data.
+
+# Prepare Environment
+
+```{r}
 # Load necessary packages:
 source("src/package_loader.R")
 
@@ -27,67 +33,329 @@ CRAN_packages <- c(
 
 lapply(CRAN_packages, package_loader)
 
+# Source all calibration functions
 walk(list.files('src/', pattern = "*.R", full.names = TRUE, recursive = TRUE), source)
 ```
 
-# Extract and Organize Calibration Data
-```{r}
-# Grab all calibration file paths
-all_cal_file_paths <- list.files(here("data", "calibration_reports"), pattern = ".html", full.names = TRUE)
+The environment setup loads essential packages for data manipulation and 
+sources all calibration functions needed for the workflow.
 
-# Grab all calibration file paths, sans vulink and virridy calibration files
-all_cal_file_paths <- all_cal_file_paths[!grepl("vulink|virridy", all_cal_file_paths)]
+# Load Calibration Data
 
-# Get the site names for each of the calibrations that we pulled
-all_cal_site_names <- basename(all_cal_file_paths) %>%
-  str_split(., "_") %>%
-  map(\(str_list){str_list[1]}) %>%
-  unlist()
+```{r load-cal-data}
+load_calibration_data()
 ```
 
-```{r}
-# Generate subset rule for the calibration names
-# Right now there is no rule.
-file_subset_rule <- grepl("/", all_cal_file_paths)
+The `load_calibration_data()` function loads the calibration coefficients and 
+drift correction information which were extracted from the HTML calibration files,
+if they exist within the file path which is provided to it. This file path, by
+default, is `here("data", "calibration_reports", "0_cal_data_munge", "munged_calibration_data.RDS")`
+
+If the data does not exist, or the `update` option is set to `TRUE`, this function 
+calls the `cal_extract_markup_data()`, which generates this calibration data 
+fresh from raw HTML files from the directory provided to it. By default these 
+directories are: `field_cal_dir = here("data", "calibration_reports")` and
+`benchtop_cal_dir = here("data", "calibration_reports", "benchtop_calibrations")`.
+Though, note that the arguments for `cal_extract_markup_data()` can be change 
+within `load_calibration_data()` via the `...` arguments. Note that `cal_extract_markup_data()`
+takes a minute to finish running.
+
+## Calibration Data Structure
+
+The resulting `calibration_data` object follows an organizational structure 
+which contains a nested list organized by year, where each year 
+contains site-parameter combinations (e.g., "lincoln-pH", "tamasag-Turbidity"). 
+Each site-parameter entry includes calibration coefficients (slope and offset values) 
+and drift correction measurements (pre- and post-calibration standard readings),
+along with their related identification and datetime information.
+
+# Load Sensor Data
+
+```{r load-snsr-data}
+# Read in 2022, 2023, 2024, and 2025 sensor data
+if (file.exists(here("data", "manual_data_verification", "complete_dataset", "23_25_hv_pull"))) {
+  sensor_data <- read_rds(here("data", "manual_data_verification", "complete_dataset", "23_25_hv_pull")) %>% 
+    set_names(names(calibration_data)) %>% 
+    compact()
+} else {
+  library(fcw.qaqc)
+  
+  sensor_data <- names(calibration_data) %>% 
+    map(function(year){
+      
+      # Grab the site for the year from the calibration_data[[year]]
+      site_list <- map(names(calibration_data[[year]]), ~word(.x, 1, sep = "-")) %>% 
+        unlist() %>% 
+        unique(.) 
+      
+      site_list <- unique(c("tamasag", "legacy", "lincoln", "timberline", "prospect", "boxelder", "archery", "river bluffs", site_list)) 
+      
+      # Generate start and end times for the HydroVu API request
+      start_dt_string <- paste0(year, "-01-01 00:00:00")
+      start_dt = as.POSIXct(start_dt_string, tz = "America/Denver")
+      start_dt_utc = with_tz(start_dt, tzone = "UTC")
+      
+      end_dt_string <- paste0(year, "-12-31 11:59:59")
+      end_dt = as.POSIXct(end_dt_string, tz = "America/Denver")
+      end_dt_utc = with_tz(end_dt, tzone = "UTC")
+      
+      api_start_dates <- tibble(site = site_list,
+                                start_DT = start_dt_utc,
+                                end_DT = end_dt_utc)
+      
+      # Grab HydroVu Credits
+      hv_creds <- read_yaml(here("creds", "HydroVuCreds.yml"))
+      
+      hv_token <- hv_auth(client_id = as.character(hv_creds["client"]),
+                          client_secret = as.character(hv_creds["secret"]))
+      
+      hv_sites <- hv_locations_all(hv_token) %>% 
+        filter(!grepl("vulink|virridy", name, ignore.case = TRUE),
+               grepl(str_flatten(site_list, collapse = "|"), name, ignore.case = TRUE))
+      
+      # Create temporary directory
+      temp_dir <- file.path(tempdir(), paste0("api_data_", year))
+      dir.create(temp_dir, showWarnings = FALSE)
+      temp_dir <- normalizePath(temp_dir)
+      
+      # Pull the API data
+      pwalk(api_start_dates,
+            function(site, start_DT, end_DT) {
+              message("Requesting HydroVu data for site: ", site)
+              fcw.qaqc::api_puller(
+                site = site,
+                start_dt = start_DT,
+                end_dt = end_DT,
+                api_token = hv_token,
+                hv_sites_arg = hv_sites,
+                # Use temporary directory for the API call
+                dump_dir = temp_dir,
+                synapse_env = FALSE,
+                fs = NULL
+              )
+            }
+      )
+      
+      # Munge the API data
+      message("Starting Munge Step")
+      
+      if (length(list.files(temp_dir)) == 0) {
+        return(NULL)
+      }
+      
+      new_data <- fcw.qaqc::munge_api_data(api_dir = temp_dir) %>% 
+        fix_sites() %>%
+        split(f = list(.$site, .$parameter), sep = "-") %>%
+        purrr::keep(~ nrow(.) > 0)
+      
+      # Tidy the API data
+      message("Starting Tidy Step")
+      sites <- unique(dplyr::bind_rows(new_data) %>% dplyr::pull(site))
+      
+      params <- c("Chl-a Fluorescence", "Depth", "DO", "ORP", "pH", "Specific Conductivity",
+                  "Pressure", "Turbidity")
+      
+      site_param_combos <- crossing(sites, params) %>% 
+        mutate(combo = paste0(sites, "-", params)) %>% 
+        pull(combo) 
+      
+      new_data <- new_data[names(new_data) %in% site_param_combos]
+      
+      sensor_data <- map(new_data, ~fcw.qaqc::tidy_api_data(api_data = .x)) %>% 
+        keep(~!is.null(.))
+      
+      # Save the API data...
+      return(sensor_data)
+    })
+  
+  # Save the raw data into a file that we can pull in in the future...
+  write_rds(sensor_data, here("data", "manual_data_verification", "complete_dataset", "23_25_hv_pull"))
+}
+
 ```
 
-```{r}
-# Grab the file paths for the subset that you are interested in
-paths_subset <- all_cal_file_paths[file_subset_rule]
+## Expected Sensor Data Structure
 
-# Subset the names of the sites based on the subset rule outcome
-subset_site_names <- basename(paths_subset) %>%
-  str_split(., "_") %>%
-  map(\(str_list){str_list[1]}) %>%
-  unlist()
+The sensor data must be organized as a year list structure where each year contains 
+site-parameter lists. For example, the 2024 data would contain separate entries 
+for "lincoln-pH", "lincoln-Turbidity", "tamasag-pH", etc. Each site-parameter 
+combination contains time series data with datetime stamps and sensor measurements. 
+This consistent structure allows the calibration functions to properly match 
+sensor readings with their corresponding calibration information.
 
-# Read in the subset of the calibration data
-subset_html <- map(paths_subset, read_html)
+# Processing steps
+
+## Join Sensor and Calibration Data
+
+```{r join-data}
+sensor_calibration_data <- cal_join_sensor_calibration_data(
+  # Sometimes the calibration date does not line up with a field visit.
+  sensor_data_list = sensor_data,
+  calibration_data_list = calibration_data
+) 
 ```
 
-```{r}
-# Extract Calibration information of subset of data
-subset <- map2_dfr(.x = subset_html,
-                   .y = subset_site_names,
-                   ~cal_extract_markup_data(html_markup = .x, calibration_site  = .y))
+The `join_sensor_calibration_data()` function links each sensor measurement to 
+its appropriate calibration information using temporal proximity matching. This 
+function identifies the most recent calibration that applies to each sensor 
+reading, creating a foundation for the back-calibration process.
+
+## Prepare Data for Back Calibration
+
+```{r prep-data}
+prepped_snsr_cal_data <- cal_prepare_sensor_calibration_data(sensor_calibration_data)
 ```
 
-```{r}
-# Clean up and organize calibration data into site-parameter combinations by year
-subset_split <- subset %>% 
-  mutate(
-    created = mdy(created),
-    last_calibrated = mdy(na_if(last_calibrated, "Factory Defaults"))
-  ) %>% 
-  split(f = year(.$created)) %>% 
-  map(\(year_data){
-    site_param_split_list <- year_data %>% 
-      filter(!(is.na(last_calibrated) & 
-         map_lgl(calibration_coefs, is.null) & 
-         map_lgl(driftr_input, is.null))) %>% 
-      split(f = list(.$calibration_site, .$sensor), sep = "-", drop = TRUE) %>%
-      discard(\(site_param_df) nrow(site_param_df) == 0) 
+The `prepare_sensor_calibration_data()` function segments the joined data into 
+calibration windows bounded by consecutive calibrations. Each window represents 
+a time period where linear interpolation between two calibrations can be applied. 
+This segmentation creates manageable chunks that allow for temporal weighting of 
+calibration parameters.
+
+# Back Calibration
+
+```{r Apply back calibration functions to the data}
+# NOTE: THIS WILL NOT RUN YET!
+calibrated_data <- prepped_snsr_cal_data %>% 
+  map(function(year){
+    calibrated_site_param_list <- year %>%
+      map(function(site_param){
+        site_param %>% 
+          map_dfr(function(chunk){
+            cal_back_calibrate(chunk) 
+          })
+      })
+  })
+```
+
+## Understanding the Nested Map Structure
+
+The back calibration process uses an explicit nested map approach that differs 
+from the simpler function calls used in previous processing steps. This design 
+choice provides three levels of iteration: years, site-parameters within each 
+year, and calibration chunks within each site-parameter. While `join_sensor_calibration_data()` 
+and `prepare_sensor_calibration_data()` handle similar nested year/site-parameter 
+iterations internally, they abstract away this complexity from the user.
+
+The explicit nested structure in  the `back_calibration()` function call serves 
+a purpose for future functionality. While automated calibration works well for 
+most situations, some sensor data may require manual intervention or custom 
+calibration approaches. The exposed nested maps allow users to easily extract 
+specific years, site-parameters, or individual chunks for manual processing 
+while maintaining the overall automated workflow for standard cases.
+
+## The `back_calibrate()` Function
+
+The `back_calibrate()` function serves as the orchestrator for the entire calibration 
+process within each chunk. It automatically determines the appropriate calibration 
+workflow based on the sensor parameter type. Standard sensors (Chlorophyll-a, 
+FDOM, ORP, Pressure, Specific Conductivity, RDO) follow a five-step process 
+involving temporal weighting, inverse linear modeling, linear transformation, 
+single-point drift correction, and validation. Turbidity sensors use a similar 
+workflow but with two-point drift correction, while pH sensors require specialized 
+three-point processing due to their multi-segment calibration approach.
+
+This function design ensures that users only need to call one function per chunk 
+while the internal logic handles the complexity of parameter-specific calibration 
+requirements.
+
+# Saving the Back-calibrated Data
+
+```{r save-cal-data}
+# write_rds(calibrated_data, here("data", "manual_data_verification", "complete_dataset", "calibrated_sensor_data.rds"))
+```
+
+# Explore the calibrations
+
+```{r explore-cal-1}
+# Functional cottonwood turbidity 2024 example to explore the calibrations:
+cottonwood_turb_2024 <- prepped_snsr_cal_data$`2024`$`cottonwood-Turbidity`
+
+# Apply the back calibration to this specific site-parameter
+cottonwood_turb_2024_calibrated <- cottonwood_turb_2024 %>% 
+  map_dfr(function(chunk){
+    cal_back_calibrate(chunk) 
   })
 
-write_rds(subset_split, here("data", "calibration_reports", "0_cal_data_munge", "munged_calibration_data.RDS"))
+# Create ggplot with basic labels and legend
+cot_turb_p <- ggplot(cottonwood_turb_2024_calibrated) +
+  geom_line(aes(x = DT_round, y = mean, color = "Original"), alpha = 0.6) +
+  geom_line(aes(x = DT_round, y = mean_raw, color = "Raw"), alpha = 0.3, linetype = "dotted") +
+  geom_line(aes(x = DT_round, y = mean_drift_trans, color = "Drift Corrected"), alpha = 0.6) +
+  geom_line(aes(x = DT_round, y = mean_lm_trans, color = "Linear Transform"), alpha = 0.6) +
+  scale_color_manual(values = c("Original" = "red", "Raw" = "yellow", 
+                               "Linear Transform" = "green", "Drift Corrected" = "blue")) +
+  labs(
+    title = "Cottonwood Turbidity 2024 Calibration",
+    x = "Date",
+    y = "Turbidity (NTU)",
+    color = "Data Type"
+  ) +
+  ylim(c(0,50)) +
+  theme_minimal()
+
+# Convert to plotly
+cot_turb_p <- ggplotly(cot_turb_p)
+
+# Add vertical lines for calibration dates
+vline_dates <- round_date(unique(cottonwood_turb_2024_calibrated$file_date), "15 minutes")
+for(date in vline_dates) {
+  cot_turb_p <- cot_turb_p %>% add_segments(x = date, xend = date, y = 0, yend = 50, 
+                         line = list(color = "black", dash = "dash"),
+                         showlegend = FALSE)
+}
+
+# Display the plot
+cot_turb_p 
 ```
+
+```{r explore-cal-2}
+# Functional archery specific conductivity 2024 example to explore the calibrations:
+archery_spc_2024 <- prepped_snsr_cal_data$`2024`$`archery-Specific Conductivity`
+
+# Apply the back calibration to this specific site-parameter
+archery_spc_2024_calibrated <- archery_spc_2024 %>% 
+  map_dfr(function(chunk){
+    cal_back_calibrate(chunk) 
+  })
+
+# Create ggplot with basic labels and legend
+arch_spc_p <- ggplot(archery_spc_2024_calibrated) +
+  geom_line(aes(x = DT_round, y = mean, color = "Original"), alpha = 0.6) +
+  geom_line(aes(x = DT_round, y = mean_raw, color = "Raw"), alpha = 0.3, linetype = "dotted") +
+  geom_line(aes(x = DT_round, y = mean_drift_trans, color = "Drift Corrected"), alpha = 0.6) +
+  geom_line(aes(x = DT_round, y = mean_lm_trans, color = "Linear Transform"), alpha = 0.6) +
+  scale_color_manual(values = c("Original" = "red", "Raw" = "yellow", 
+                               "Linear Transform" = "green", "Drift Corrected" = "blue")) +
+  labs(
+    title = "Archery Specific Conductivity 2024 Calibration",
+    x = "Date",
+    y = "Specific Conductivity (μS/cm)",
+    color = "Data Type"
+  ) +
+  theme_minimal()
+
+# Convert to plotly
+arch_spc_p <- ggplotly(arch_spc_p)
+
+# Add vertical lines for calibration dates
+vline_dates <- round_date(unique(archery_spc_2024_calibrated$file_date), "15 minutes")
+for(date in vline_dates) {
+  arch_spc_p <- arch_spc_p %>% add_segments(x = date, xend = date, 
+                         y = min(archery_spc_2024_calibrated$mean_drift_trans, na.rm = TRUE), 
+                         yend = max(archery_spc_2024_calibrated$mean_drift_trans, na.rm = TRUE), 
+                         line = list(color = "black", dash = "dash"),
+                         showlegend = FALSE)
+}
+
+# Display the plot
+arch_spc_p
+```
+
+# Workflow Summary
+The complete calibration workflow transforms raw sensor data through four main stages. 
+First, calibration information is loaded and joined with sensor data using temporal 
+matching. Second, the joined data is segmented into calibration windows for processing. 
+Third, each window undergoes back calibration using parameter-specific algorithms 
+that account for instrument characteristics and drift patterns. Finally, the calibrated 
+results are validated and compiled into a clean time series dataset ready for analysis.

--- a/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
+++ b/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
@@ -215,7 +215,6 @@ calibration parameters.
 # Back Calibration
 
 ```{r Apply back calibration functions to the data}
-# NOTE: THIS WILL NOT RUN YET!
 calibrated_data <- prepped_snsr_cal_data %>% 
   map(function(year){
     calibrated_site_param_list <- year %>%

--- a/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
+++ b/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
@@ -236,7 +236,7 @@ year, and calibration chunks within each site-parameter. While `join_sensor_cali
 and `prepare_sensor_calibration_data()` handle similar nested year/site-parameter 
 iterations internally, they abstract away this complexity from the user.
 
-The explicit nested structure in  the `back_calibration()` function call serves 
+The explicit nested structure in  the `cal_back_calibration()` function call serves 
 a purpose for future functionality. While automated calibration works well for 
 most situations, some sensor data may require manual intervention or custom 
 calibration approaches. The exposed nested maps allow users to easily extract 

--- a/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
+++ b/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
@@ -243,7 +243,7 @@ calibration approaches. The exposed nested maps allow users to easily extract
 specific years, site-parameters, or individual chunks for manual processing 
 while maintaining the overall automated workflow for standard cases.
 
-## The `back_calibrate()` Function
+## The `cal_back_calibrate()` Function
 
 The `cal_back_calibrate()` function serves as the orchestrator for the entire calibration 
 process within each chunk. It automatically determines the appropriate calibration 

--- a/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
+++ b/scratch/data_tidying/sensor_calibration/fixing_calibrations.Rmd
@@ -262,94 +262,53 @@ requirements.
 # Saving the Back-calibrated Data
 
 ```{r save-cal-data}
-# write_rds(calibrated_data, here("data", "manual_data_verification", "complete_dataset", "calibrated_sensor_data.rds"))
+write_rds(calibrated_data, here("data", "manual_data_verification", "complete_dataset", "calibrated_sensor_data.rds"))
 ```
 
 # Explore the calibrations
 
-```{r explore-cal-1}
-# Functional cottonwood turbidity 2024 example to explore the calibrations:
-cottonwood_turb_2024 <- prepped_snsr_cal_data$`2024`$`cottonwood-Turbidity`
+```{r explore-cal}
+# update `calibrated_test` object with the data you would like to explore...
+calibrated_test <- calibrated_data$`2024`$`cottonwood-Turbidity`
 
-# Apply the back calibration to this specific site-parameter
-cottonwood_turb_2024_calibrated <- cottonwood_turb_2024 %>% 
-  map_dfr(function(chunk){
-    cal_back_calibrate(chunk) 
-  })
+# Extract parameter and site info for dynamic labeling
+parameter <- unique(calibrated_test$parameter)
+site <- unique(calibrated_test$site)
 
 # Create ggplot with basic labels and legend
-cot_turb_p <- ggplot(cottonwood_turb_2024_calibrated) +
+calibration_p_test <- ggplot(calibrated_test) +
   geom_line(aes(x = DT_round, y = mean, color = "Original"), alpha = 0.6) +
   geom_line(aes(x = DT_round, y = mean_raw, color = "Raw"), alpha = 0.3, linetype = "dotted") +
   geom_line(aes(x = DT_round, y = mean_drift_trans, color = "Drift Corrected"), alpha = 0.6) +
   geom_line(aes(x = DT_round, y = mean_lm_trans, color = "Linear Transform"), alpha = 0.6) +
   scale_color_manual(values = c("Original" = "red", "Raw" = "yellow", 
-                               "Linear Transform" = "green", "Drift Corrected" = "blue")) +
+                                "Linear Transform" = "green", "Drift Corrected" = "blue")) +
   labs(
-    title = "Cottonwood Turbidity 2024 Calibration",
+    title = paste(site, parameter, "2024 Calibration"),
     x = "Date",
-    y = "Turbidity (NTU)",
+    y = paste(parameter, "(units)"),
     color = "Data Type"
   ) +
   ylim(c(0,50)) +
   theme_minimal()
 
 # Convert to plotly
-cot_turb_p <- ggplotly(cot_turb_p)
+calibration_p_test <- ggplotly(calibration_p_test)
 
 # Add vertical lines for calibration dates
-vline_dates <- round_date(unique(cottonwood_turb_2024_calibrated$file_date), "15 minutes")
+vline_dates <- round_date(unique(calibrated_test$file_date), "15 minutes")
 for(date in vline_dates) {
-  cot_turb_p <- cot_turb_p %>% add_segments(x = date, xend = date, y = 0, yend = 50, 
-                         line = list(color = "black", dash = "dash"),
-                         showlegend = FALSE)
+  calibration_p_test <- calibration_p_test %>% add_segments(x = date, xend = date, 
+                                                            y = min(calibrated_test$mean_drift_trans, na.rm = TRUE), 
+                                                            yend = max(calibrated_test$mean_drift_trans, na.rm = TRUE), 
+                                                            line = list(color = "black", dash = "dash"),
+                                                            showlegend = FALSE)
 }
 
 # Display the plot
-cot_turb_p 
-```
+calibration_p_test <- ggplotly(calibration_p_test)
 
-```{r explore-cal-2}
-# Functional archery specific conductivity 2024 example to explore the calibrations:
-archery_spc_2024 <- prepped_snsr_cal_data$`2024`$`archery-Specific Conductivity`
-
-# Apply the back calibration to this specific site-parameter
-archery_spc_2024_calibrated <- archery_spc_2024 %>% 
-  map_dfr(function(chunk){
-    cal_back_calibrate(chunk) 
-  })
-
-# Create ggplot with basic labels and legend
-arch_spc_p <- ggplot(archery_spc_2024_calibrated) +
-  geom_line(aes(x = DT_round, y = mean, color = "Original"), alpha = 0.6) +
-  geom_line(aes(x = DT_round, y = mean_raw, color = "Raw"), alpha = 0.3, linetype = "dotted") +
-  geom_line(aes(x = DT_round, y = mean_drift_trans, color = "Drift Corrected"), alpha = 0.6) +
-  geom_line(aes(x = DT_round, y = mean_lm_trans, color = "Linear Transform"), alpha = 0.6) +
-  scale_color_manual(values = c("Original" = "red", "Raw" = "yellow", 
-                               "Linear Transform" = "green", "Drift Corrected" = "blue")) +
-  labs(
-    title = "Archery Specific Conductivity 2024 Calibration",
-    x = "Date",
-    y = "Specific Conductivity (μS/cm)",
-    color = "Data Type"
-  ) +
-  theme_minimal()
-
-# Convert to plotly
-arch_spc_p <- ggplotly(arch_spc_p)
-
-# Add vertical lines for calibration dates
-vline_dates <- round_date(unique(archery_spc_2024_calibrated$file_date), "15 minutes")
-for(date in vline_dates) {
-  arch_spc_p <- arch_spc_p %>% add_segments(x = date, xend = date, 
-                         y = min(archery_spc_2024_calibrated$mean_drift_trans, na.rm = TRUE), 
-                         yend = max(archery_spc_2024_calibrated$mean_drift_trans, na.rm = TRUE), 
-                         line = list(color = "black", dash = "dash"),
-                         showlegend = FALSE)
-}
-
-# Display the plot
-arch_spc_p
+calibration_p_test
 ```
 
 # Workflow Summary

--- a/src/cal_back_calibrate.R
+++ b/src/cal_back_calibrate.R
@@ -1,0 +1,84 @@
+#' @title Back Calibration Orchestrator
+#'
+#' @description
+#' Orchestrates the complete back calibration workflow for sensor data chunks
+#' bounded by two calibrations. This function determines the appropriate
+#' calibration pathway based on sensor parameter type and applies the
+#' corresponding sequence of correction functions. Standard sensors follow a
+#' five-step process, turbidity uses two-point drift correction, and pH sensors
+#' require specialized three-point processing with unit conversions.
+#'
+#' @param prepped_snsr_cal_df Tibble containing prepared sensor calibration data
+#'   chunk from prepare_sensor_calibration_data(), bounded by two calibrations
+#'
+#' @seealso [cal_wt()]
+#' @seealso [cal_inv_lm()]
+#' @seealso [cal_lin_trans_lm()]
+#' @seealso [cal_one_point_drift()]
+#' @seealso [cal_two_point_drift()]
+#' @seealso [cal_lm_pH()]
+#' @seealso [cal_lin_trans_inv_lm_pH()]
+#' @seealso [cal_three_point_drift_pH()]
+#' @seealso [cal_check()]
+
+cal_back_calibrate <- function(prepped_snsr_cal_df) {
+
+  # Identify sensor parameter type for calibration pathway selection
+  parameter <- unique(prepped_snsr_cal_df$parameter)
+
+  # Standard sensor calibration pathway (five-step process)
+  if (parameter %in% c("Chlorophyll-a", "FDOM Fluorescence", "ORP", "Pressure", "Specific Conductivity", "RDO")) {
+    back_calibrated_chunk <- prepped_snsr_cal_df %>%
+      # Calculate temporal weights for calibration interpolation
+      cal_wt(df = ., dt_col = "DT_round") %>%
+      # Convert observed values back to raw instrumental units
+      cal_inv_lm(df = ., obs_col = "mean", lm_coefs_col = "calibration_coefs") %>%
+      # Apply temporally-weighted linear transformation between calibrations
+      cal_lin_trans_lm(df = ., raw_col = "mean_raw", lm_coefs_col = "calibration_coefs", wt_col = "wt") %>%
+      # Apply single-point drift correction
+      cal_one_point_drift(df = ., lm_trans_col = "mean_lm_trans", drift_corr_col = "drift_input", wt_col = "wt") %>%
+      # Validate calibration results and create final calibrated values
+      cal_check(df = ., obs_col = "mean", lm_trans_col = "mean_lm_trans")
+    return(head(back_calibrated_chunk, -1))
+  }
+
+  # Turbidity sensor calibration pathway (two-point drift correction)
+  if (parameter == "Turbidity") {
+    back_calibrated_chunk <- prepped_snsr_cal_df %>%
+      # Calculate temporal weights for calibration interpolation
+      cal_wt(df = ., dt_col = "DT_round") %>%
+      # Convert observed values back to raw instrumental units
+      cal_inv_lm(df = ., obs_col = "mean", lm_coefs_col = "calibration_coefs") %>%
+      # Apply temporally-weighted linear transformation between calibrations
+      cal_lin_trans_lm(df = ., raw_col = "mean_raw", lm_coefs_col = "calibration_coefs", wt_col = "wt") %>%
+      # Apply two-point drift correction for turbidity-specific drift patterns
+      cal_two_point_drift(df = ., lm_trans_col = "mean_lm_trans", drift_corr_col = "drift_input", wt_col = "wt") %>%
+      # Validate calibration results and create final calibrated values
+      cal_check(df = ., obs_col = "mean", lm_trans_col = "mean_lm_trans")
+    return(head(back_calibrated_chunk, -1))
+  }
+
+  # pH sensor calibration pathway (specialized three-point processing)
+  # pH calibration requires special handling due to:
+  # - Slopes in mV/pH units and offsets in mV units (not direct pH units)
+  # - Three-point calibration creating two slope transitions
+  # - Need for unit conversion from pH to mV for back-calibration
+  # - Three-point drift correction with piecewise linear interpolation
+  if (parameter == "pH"){
+    back_calibrated_chunk <- prepped_snsr_cal_df %>%
+      # Calculate temporal weights for calibration interpolation
+      cal_wt(df = ., dt_col = "DT_round") %>%
+      # Convert pH values to millivolt units for back-calibration processing
+      cal_lm_pH(df = ., obs_col = "mean", lm_coefs_col = "calibration_coefs") %>%
+      # Apply temporally-weighted inverse transformation back to pH units
+      cal_lin_trans_inv_lm_pH(df = ., obs_col = "mean", mv_col = "mean_mV_f", lm_coefs_col = "calibration_coefs", wt_col = "wt") %>%
+      # Apply three-point drift correction with piecewise linear interpolation
+      cal_three_point_drift_pH(df = ., obs_col = "mean", lm_trans_col = "mean_pH_f", drift_corr_col = "drift_input", wt_col = "wt") %>%
+      # Validate calibration results and create final calibrated values
+      cal_check(df = ., obs_col = "mean", lm_trans_col = "mean_pH_f")
+    return(head(back_calibrated_chunk, -1))
+  }
+
+  # Return NULL result if parameter type is not recognized
+  return(NULL)
+}

--- a/src/cal_back_calibrate.R
+++ b/src/cal_back_calibrate.R
@@ -27,18 +27,18 @@ cal_back_calibrate <- function(prepped_snsr_cal_df) {
   parameter <- unique(prepped_snsr_cal_df$parameter)
 
   # Standard sensor calibration pathway (five-step process)
-  if (parameter %in% c("Chlorophyll-a", "FDOM Fluorescence", "ORP", "Pressure", "Specific Conductivity", "RDO")) {
+  if (parameter %in% c("Chl-a Fluorescence", "FDOM Fluorescence", "ORP", "Pressure", "Specific Conductivity", "RDO")) {
     back_calibrated_chunk <- prepped_snsr_cal_df %>%
-      # Calculate temporal weights for calibration interpolation
-      cal_wt(df = ., dt_col = "DT_round") %>%
-      # Convert observed values back to raw instrumental units
-      cal_inv_lm(df = ., obs_col = "mean", lm_coefs_col = "calibration_coefs") %>%
-      # Apply temporally-weighted linear transformation between calibrations
-      cal_lin_trans_lm(df = ., raw_col = "mean_raw", lm_coefs_col = "calibration_coefs", wt_col = "wt") %>%
-      # Apply single-point drift correction
-      cal_one_point_drift(df = ., lm_trans_col = "mean_lm_trans", drift_corr_col = "drift_input", wt_col = "wt") %>%
-      # Validate calibration results and create final calibrated values
-      cal_check(df = ., obs_col = "mean", lm_trans_col = "mean_lm_trans")
+        # Calculate temporal weights for calibration interpolation
+        cal_wt(df = ., dt_col = "DT_round") %>%
+        # Convert observed values back to raw instrumental units
+        cal_inv_lm(df = ., obs_col = "mean", lm_coefs_col = "calibration_coefs") %>%
+        # Apply temporally-weighted linear transformation between calibrations
+        cal_lin_trans_lm(df = ., raw_col = "mean_raw", lm_coefs_col = "calibration_coefs", wt_col = "wt") %>%
+        # Apply single-point drift correction
+        cal_one_point_drift(df = ., lm_trans_col = "mean_lm_trans", drift_corr_col = "drift_input", wt_col = "wt") %>%
+        # Validate calibration results and create final calibrated values
+        cal_check(df = ., obs_col = "mean", lm_trans_col = "mean_lm_trans")
     return(head(back_calibrated_chunk, -1))
   }
 

--- a/src/cal_check.R
+++ b/src/cal_check.R
@@ -1,0 +1,39 @@
+#' @title Calibration Validation and Final Value Selection
+#'
+#' @description
+#' Validates calibration results and creates final calibrated values by
+#' comparing transformed data against original observations. This function
+#' prioritizes linearly transformed values over drift-corrected values and
+#' falls back to original observations when calibration fails. Creates a
+#' calibration success flag for quality control purposes.
+#'
+#' @param df Tibble containing sensor data with calibration transformations
+#' @param obs_col Character string specifying the column name containing
+#'   original sensor observations
+#' @param lm_trans_col Character string specifying the column name containing
+#'   linearly transformed calibration values (excludes drift correction)
+#'
+#' @seealso [cal_lin_trans_lm()]
+#' @seealso [cal_one_point_drift()]
+#' @seealso [cal_two_point_drift()]
+#' @seealso [cal_three_point_drift_pH()]
+
+cal_check <- function(df, obs_col, lm_trans_col) {
+
+  # Create output column name for final calibrated values
+  transformed_col <- paste0(obs_col, "_cal")
+
+  # Check if all linearly transformed values are missing (calibration failure)
+  all_na <- all(is.na(df[[lm_trans_col]]))
+
+  # Create final calibrated values and quality control flag
+  df <- df %>%
+    mutate(
+      # Use linearly transformed values if available, otherwise fall back to original observations
+      !!transformed_col := ifelse(all_na, .data[[obs_col]], .data[[lm_trans_col]]),
+      # Create calibration success flag for quality control
+      cal_check = ifelse(!all_na, TRUE, FALSE)
+    )
+
+  return(df)
+}

--- a/src/cal_check.R
+++ b/src/cal_check.R
@@ -29,11 +29,12 @@ cal_check <- function(df, obs_col, lm_trans_col) {
   # Create final calibrated values and quality control flag
   df <- df %>%
     mutate(
-      # Use linearly transformed values if available, otherwise fall back to original observations
-      !!transformed_col := ifelse(all_na, .data[[obs_col]], .data[[lm_trans_col]]),
       # Create calibration success flag for quality control
-      cal_check = ifelse(!all_na, TRUE, FALSE)
-    )
+      cal_check = ifelse(!all_na, TRUE, FALSE),
+      # Use linearly transformed values if available, otherwise fall back to original observations
+      !!transformed_col := ifelse(cal_check, .data[[lm_trans_col]], .data[[obs_col]])
+    ) %>%
+    relocate(cal_check, .after = !!transformed_col)
 
   return(df)
 }

--- a/src/cal_extract_conductivity_data.R
+++ b/src/cal_extract_conductivity_data.R
@@ -75,29 +75,33 @@ cal_extract_conductivity_data <- function(div) {
   driftr_data_check_1 <- cal_div_table_check(
     table_list = div_tables,
     table_name = "pre_measurement",
-    col_names = c("actual_conductivity", "specific_conductivity")
+    col_names = c("specific_conductivity")
   )
 
   driftr_data_check_2 <- cal_div_table_check(
     table_list = div_tables,
     table_name = "post_measurement",
-    col_names = c("actual_conductivity", "specific_conductivity")
+    col_names = c("specific_conductivity")
   )
 
   if (driftr_data_check_1 && driftr_data_check_2) {
 
   calibration_1 <- div_tables[["pre_measurement"]] %>%
-    pivot_wider(names_from = X1, values_from = X2, names_repair = make_clean_names)
+    pivot_wider(names_from = X1, values_from = X2, names_repair = make_clean_names) %>%
+    select(-actual_conductivity) %>%
+    rename(pre_measurement = specific_conductivity)
 
   calibration_2 <- div_tables[["post_measurement"]] %>%
-    pivot_wider(names_from = X1, values_from = X2, names_repair = make_clean_names)
+    pivot_wider(names_from = X1, values_from = X2, names_repair = make_clean_names) %>%
+    select(-actual_conductivity) %>%
+    rename(post_measurement = specific_conductivity)
 
-  driftr_input <- tibble(point = c(1,2), bind_rows(calibration_1,calibration_2)) %>%
+  driftr_input <- tibble(point = c(1), bind_cols(calibration_1,calibration_2)) %>%
     mutate(
-      units = word(specific_conductivity, 2),
-      across(c(actual_conductivity, specific_conductivity), ~word(.x, 1)), # get rid of units in measurements
-      across(c(actual_conductivity, specific_conductivity), ~gsub(",", "", .x)), # get rid of commas
-      across(c(actual_conductivity, specific_conductivity), ~as.numeric(.x)) # convert to numeric
+      units = word(post_measurement, 2),
+      across(c(pre_measurement, post_measurement), ~word(.x, 1)), # get rid of units in measurements
+      across(c(pre_measurement, post_measurement), ~gsub(",", "", .x)), # get rid of commas
+      across(c(pre_measurement, post_measurement), ~as.numeric(.x)) # convert to numeric
     )
   } else {
     driftr_input <- NULL

--- a/src/cal_extract_markup_data.R
+++ b/src/cal_extract_markup_data.R
@@ -1,70 +1,225 @@
-cal_extract_markup_data <- function(html_markup, calibration_site) {
+#' @title Extract Calibration Data from HTML Markup
+#'
+#' @description
+#' Extracts calibration coefficients and drift correction information from HTML
+#' calibration report files. This function processes both field and benchtop
+#' calibration files, extracting slope/offset parameters and pre/post measurement
+#' data for each sensor. Organizes the extracted data into a nested list structure
+#' by year and site-parameter combinations, with field calibrations taking
+#' priority over benchtop calibrations when both are available.
+#'
+#' @param field_cal_dir Character string specifying the directory path containing
+#'   field calibration HTML files (default: data/calibration_reports/)
+#' @param benchtop_cal_dir Character string specifying the directory path
+#'   containing benchtop calibration HTML files (default:
+#'   data/calibration_reports/benchtop_calibrations/)
+#'
+#' @seealso [load_calibration_data()]
+#' @seealso [join_sensor_calibration_data()]
 
-  # Establish sensors we are retrieiving data for
-  sensor_list <- c("chlorophyll_a",
-                   "conductivity",
-                   "fdom",
-                   "p_h_orp",
-                   "pressure",
-                   "rdo",
-                   "turbidity")
+cal_extract_markup_data <- function(field_cal_dir = here("data", "calibration_reports"),
+                                    benchtop_cal_dir = here("data", "calibration_reports", "benchtop_calibrations")){
 
-  # Grab the metadata for the overall calibration
-  cal_metadata <- html_markup %>%
-    html_elements("table") %>%
-    html_table() %>%
-    pluck(1) %>%
-    pivot_wider(names_from = X1, values_from = X2) %>%
-    clean_names() %>%
-    mutate(instrument = make_clean_names(instrument)) %>%
-    rename(sonde_serial = serial_number)
+  # Prepare field calibrations for extraction ====
+  # Identify and filter field calibration HTML files
+  f_cal_paths <- list.files(field_cal_dir, pattern = ".html", full.names = T)
+  f_cal_paths <- discard(f_cal_paths, ~grepl("vulink|virridy", .x, ignore.case = T))
 
-  # Grab the div metadata for the html_markup file
-  # Each div is for one parameter
-  html_divs <- html_markup %>%
-    html_elements("div")
+  # Extract site names and datetime information from field calibration file paths
+  f_cal_info <- f_cal_paths %>%
+    map(function(path_str){
+      str_list <- basename(path_str) %>%
+        str_split_1("_|\\.") %>%
+        str_squish()
 
-  html_div_info <- html_divs %>%
-    map_dfr(function(div){
+      # Parse site name from filename
+      site <- str_list[1]
 
-      sensor <- div %>%
+      # Parse and convert datetime to UTC
+      date <- str_list[2:3] %>%
+        str_flatten(collapse = " ") %>%
+        str_squish() %>%
+        ymd_hm(tz = "America/Denver") %>%
+        with_tz(tzone = "UTC")
+
+      cal_info <- tibble(site = site, date = date)
+      return(cal_info)
+    })
+
+  # Prepare benchtop calibrations for extraction ====
+  # Identify and filter benchtop calibration HTML files
+  b_cal_paths <- list.files(benchtop_cal_dir, pattern = ".html", full.names = T)
+  b_cal_paths <- discard(b_cal_paths, ~grepl("vulink|virridy", .x, ignore.case = T))
+
+  # Extract datetime information from benchtop calibration file paths
+  b_cal_info <- b_cal_paths %>%
+    map(function(path_str){
+      str_list <- basename(path_str) %>%
+        str_split_1("_|\\.") %>%
+        str_squish() %>%
+        discard(~grepl("VuSitu|Calibration|html", .x, ignore.case = T))
+
+      # Handle different datetime formats in benchtop filenames
+      if (length(str_list) == 2){
+        date <- with_tz(ymd(str_list[2]), tzone = "UTC")
+      } else if (length(str_list) == 3){
+        unix_dt <- as.numeric(str_list[3])/1000
+        date <- with_tz(as_datetime(unix_dt, tz = "America/Denver", origin = origin), tzone = "UTC")
+      }
+
+      cal_info <- tibble(site = "benchtop", date = date)
+      return(cal_info)
+    })
+
+  # Extract calibration information from all HTML files ====
+  # Combine field and benchtop calibration file paths and metadata
+  cal_paths <- c(f_cal_paths, b_cal_paths)
+  cal_info <- c(f_cal_info, b_cal_info)
+
+  # Load HTML markup from all calibration files
+  cal_html <- map(cal_paths, read_html)
+
+  # Extract calibration data from each HTML file
+  cal_data <- map2_dfr(
+    cal_html, cal_info,
+    function(html_markup, calibration_information){
+
+      # Extract overall calibration metadata from first table
+      file_information <- html_markup %>%
         html_elements("table") %>%
         html_table() %>%
         pluck(1) %>%
-        pivot_wider(names_from = X1, values_from = X2, names_repair = make_clean_names) %>%
-        mutate(sensor = make_clean_names(sensor)) %>%
-        pull(sensor)
+        pivot_wider(names_from = X1, values_from = X2) %>%
+        clean_names() %>%
+        mutate(instrument = make_clean_names(instrument)) %>%
+        rename(sonde_serial = serial_number)
 
-      if (sensor %in% sensor_list){
-        div_table_data <- switch(
-          EXPR = sensor,
-          "conductivity" = cal_extract_conductivity_data(div),
-          "rdo" = cal_extract_rdo_data(div),
-          "p_h_orp" = cal_extract_ph_orp_data(div),
-          "pressure" = cal_extract_pressure_data(div),
-          "turbidity" = cal_extract_turbidity_data(div),
-          "fdom" = cal_extract_fdom_data(div),
-          "chlorophyll_a" = cal_extract_chla_data(div)
-        )
-      } else {
-        return()
-      }
+      # Extract sensor-specific calibration data from each div element
+      html_divs <- html_markup %>%
+        html_elements("div")
 
-      return(div_table_data)
+      # Process each sensor div for calibration coefficients and drift data
+      html_div_info <- html_divs %>%
+        map_dfr(function(div){
+          # Identify sensor type from div metadata
+          sensor <- div %>%
+            html_elements("table") %>%
+            html_table() %>%
+            pluck(1) %>%
+            pivot_wider(names_from = X1, values_from = X2, names_repair = make_clean_names) %>%
+            mutate(sensor = make_clean_names(sensor)) %>%
+            pull(sensor)
 
+          # Extract sensor-specific calibration data using appropriate extraction function
+          if (sensor %in% c("chlorophyll_a", "conductivity", "fdom", "p_h_orp", "pressure", "rdo", "turbidity")){
+            div_table_data <- switch(
+              EXPR = sensor,
+              "conductivity" = cal_extract_conductivity_data(div),
+              "rdo" = cal_extract_rdo_data(div),
+              "p_h_orp" = cal_extract_ph_orp_data(div),
+              "pressure" = cal_extract_pressure_data(div),
+              "turbidity" = cal_extract_turbidity_data(div),
+              "fdom" = cal_extract_fdom_data(div),
+              "chlorophyll_a" = cal_extract_chla_data(div)
+            )
+          } else {
+            return()
+          }
+          return(div_table_data)
+        })
+
+      # Combine metadata with extracted sensor data
+      markup_data <- tibble(
+        calibration_information,
+        file_information,
+        html_div_info
+      ) %>%
+        # Standardize site names using fix_sites() function
+        fix_sites() %>%
+        # Standardize sensor parameter names to match sensor data conventions
+        mutate(
+          sensor = case_when(
+            sensor == "chlorophyll_a" ~ "Chl-a Fluorescence",
+            sensor == "conductivity" ~ "Specific Conductivity",
+            sensor == "fdom" ~ "FDOM Fluorescence",
+            sensor == "p_h" ~ "pH",
+            sensor == "orp" ~ "ORP",
+            sensor == "pressure" ~ "Pressure",
+            sensor == "rdo" ~ "RDO",
+            sensor == "turbidity" ~ "Turbidity",
+            .default = sensor
+          )
+        ) %>%
+        # Rename datetime columns for clarity
+        rename(file_date = date, sonde_date = created, sensor_date = last_calibrated)
+
+      return(markup_data)
     })
 
-  # Generate the metadata for the whole file
-  metadata <- tibble(
-    calibration_site,
-    cal_metadata,
-    html_div_info
-  )
+  # Organize extracted calibration information ====
+  # Separate field and benchtop calibration data for merging
+  f_cal_data <- filter(cal_data, site != "benchtop")
+  b_cal_data <- filter(cal_data, site == "benchtop") %>%
+    select(sensor, sensor_serial, sensor_date, calibration_coefs, driftr_input)
 
-  return(metadata)
+  # Merge field and benchtop calibrations, prioritizing field calibrations
+  calibrations <- left_join(f_cal_data, b_cal_data,
+                            by = c("sensor", "sensor_serial", "sensor_date"),
+                            suffix = c(".field", ".benchtop"),
+                            relationship = "many-to-many") %>%
+    # Coalesce calibration data, preferring field calibrations over benchtop
+    mutate(
+      calibration_coefs = map2(calibration_coefs.field, calibration_coefs.benchtop,
+                               ~ if(!is.null(.x)) .x else .y),
+      drift_input = map2(driftr_input.field, driftr_input.benchtop,
+                         ~ if(!is.null(.x)) .x else .y),
+      calibration_coefs = map(calibration_coefs, ~ if(is.null(.x)) NA else .x),
+      drift_input = map(drift_input, ~ if(is.null(.x)) NA else .x)
+    ) %>%
+    # Clean up merged columns and filter valid calibrations
+    select(-ends_with(".field"), -ends_with(".benchtop")) %>%
+    filter(!is.na(calibration_coefs) | !is.na(drift_input)) %>%
+    # Organize columns by data type
+    select(
+      # Site and sensor identification
+      site, sensor,
+      # Datetime information
+      file_date, sonde_date, sensor_date,
+      # Instrument identification
+      sonde_serial, sensor_serial,
+      # Calibration data
+      calibration_coefs, drift_input
+    )
+
+  # Structure calibration data by year and site-parameter combinations
+  calibrations_list <- calibrations %>%
+    # Parse datetime columns
+    mutate(
+      sonde_date = mdy(sonde_date),
+      sensor_date = mdy(na_if(sensor_date, "Factory Defaults"))
+    ) %>%
+    # Split by year
+    split(f = year(.$file_date)) %>%
+    map(\(year_data){
+      # Split each year by site-parameter combinations
+      site_param_split_list <- year_data %>%
+        split(f = list(.$site, .$sensor), sep = "-", drop = TRUE) %>%
+        discard(\(site_param_df) nrow(site_param_df) == 0) %>%
+        map(function(site_param_df){
+          site_param_df %>%
+            # Deduplicate calibrations by selecting most recent per day
+            group_by(sensor, sonde_date, sensor_serial) %>%
+            slice_max(file_date, n = 1, with_ties = F) %>%
+            ungroup() %>%
+            # Select most recent calibration per sensor
+            group_by(sensor, sensor_date, sensor_serial) %>%
+            slice_min(file_date, n = 1, with_ties = F) %>%
+            ungroup() %>%
+            # Remove any remaining duplicates
+            distinct()
+        })
+    })
+
+  # Return organized calibration data structure
+  return(calibrations_list)
 }
-
-
-
-
-

--- a/src/cal_inv_lm.R
+++ b/src/cal_inv_lm.R
@@ -1,0 +1,42 @@
+#' @title Inverse Linear Model Transformation
+#'
+#' @description
+#' Converts sensor observations back to raw instrumental values by applying the
+#' inverse of the linear calibration model. This function reverses the
+#' slope/offset transformation applied by the sensor to recover the original raw
+#' measurements, enabling subsequent re-calibration with updated parameters.
+#'
+#' @param df Tibble containing sensor data bounded by two calibrations
+#' @param obs_col Character string specifying the column name containing
+#'   observations recorded in HydroVu
+#' @param lm_coefs_col Character string specifying the column name containing
+#'   linear model coefficients
+#'
+#' @seealso [cal_wt()]
+#' @seealso [cal_lin_trans_lm()]
+
+cal_inv_lm <- function(df, obs_col, lm_coefs_col){
+
+  # Create output column name for raw values
+  raw_col <- paste0(obs_col, "_raw")
+
+  # Extract calibration coefficients from first calibration
+  calibration_1 <- df[[lm_coefs_col]][[1]]
+
+  # Handle missing calibration data
+  if (is.null(calibration_1)) {
+    df <- df %>%
+      mutate(!!raw_col := NA_integer_)
+    return(df)
+  }
+
+  # Extract slope and offset parameters for inverse transformation
+  slope_1 <- as.numeric(calibration_1 %>% pull(slope))
+  offset_1 <- as.numeric(calibration_1 %>% pull(offset))
+
+  # Apply inverse linear model transformation: x = (y - b) / m
+  df <- df %>%
+    mutate(!!raw_col := (.data[[obs_col]] - offset_1) / slope_1)
+
+  return(df)
+}

--- a/src/cal_inv_lm.R
+++ b/src/cal_inv_lm.R
@@ -24,7 +24,7 @@ cal_inv_lm <- function(df, obs_col, lm_coefs_col){
   calibration_1 <- df[[lm_coefs_col]][[1]]
 
   # Handle missing calibration data
-  if (is.null(calibration_1)) {
+  if (!is.data.frame(calibration_1) || nrow(calibration_1) == 0) {
     df <- df %>%
       mutate(!!raw_col := NA_integer_)
     return(df)

--- a/src/cal_join_sensor_calibration_data.R
+++ b/src/cal_join_sensor_calibration_data.R
@@ -1,0 +1,61 @@
+#' @title Join Sensor and Calibration Data
+#'
+#' @description
+#' Joins sensor time series data with calibration information using temporal
+#' proximity matching. This function links each sensor measurement to the most
+#' recent applicable calibration by finding the closest calibration date that
+#' precedes or equals each sensor observation timestamp. Processes data
+#' hierarchically by year and site-parameter combinations to maintain data
+#' organization structure.
+#'
+#' @param sensor_data_list Nested list containing sensor time series data
+#'   organized by year and site-parameter combinations
+#' @param calibration_data_list Nested list containing calibration data
+#'   organized by year and site-parameter combinations from
+#'   load_calibration_data()
+#'
+#' @seealso [load_calibration_data()]
+#' @seealso [prepare_sensor_calibration_data()]
+
+# TODO: Fix the join so that it joins on site visits
+cal_join_sensor_calibration_data <- function(sensor_data_list, calibration_data_list) {
+
+  # Identify overlapping years between sensor and calibration data
+  years <- intersect(names(sensor_data_list), names(calibration_data_list))
+
+  # Process each year of data
+  year_data_list <- years %>%
+    map(function(year){
+
+      # Extract sensor and calibration data for current year
+      year_sensor_data <- sensor_data_list[[year]]
+      year_calibration_data <- calibration_data_list[[year]]
+
+      # Identify overlapping site-parameter combinations within the year
+      site_params <- intersect(names(sensor_data_list[[year]]), names(calibration_data_list[[year]]))
+
+      # Process each site-parameter combination
+      site_param_df_list <- site_params %>%
+        map(function(site_param){
+
+          # Extract data for current site-parameter combination
+          sensor_data <- year_sensor_data[[site_param]]
+          calibration_data <- select(year_calibration_data[[site_param]], -sensor)
+
+          # Join calibration data to sensor data using temporal proximity matching
+          # For each sensor timestamp, find the most recent calibration that
+          # precedes or equals the sensor measurement time
+          by <- join_by(site, closest(DT_round >= file_date))
+          joined_sensor_calibration_data <- left_join(sensor_data, calibration_data, by) %>%
+            arrange(DT_round)
+
+          return(joined_sensor_calibration_data)
+        }) %>%
+        set_names(site_params)
+
+      return(site_param_df_list)
+    }) %>%
+    set_names(years)
+
+  return(year_data_list)
+}

--- a/src/cal_lin_trans_inv_lm_pH.R
+++ b/src/cal_lin_trans_inv_lm_pH.R
@@ -1,0 +1,80 @@
+#' @title Linear Transition Between Inverse Linear Models (pH Specific)
+#'
+#' @description
+#' Converts millivolt values back to pH units using temporally-weighted inverse
+#' linear transformation between two consecutive calibrations. This function
+#' applies two-segment inverse linear models with temporal interpolation to
+#' account for sensor drift across the calibration window. Uses pH value
+#' thresholds to select between low-range and high-range inverse transformations
+#' based on the original pH observations.
+#'
+#' @param df Tibble containing sensor data bounded by two calibrations
+#' @param obs_col Character string specifying the column name containing
+#'   original pH observations for range selection logic (default: "mean")
+#' @param mv_col Character string specifying the column name containing
+#'   millivolt values from pH linear model transformation (default: "mean_mV_f")
+#' @param lm_coefs_col Character string specifying the column name containing
+#'   linear model coefficients (default: "calibration_coefs")
+#' @param wt_col Character string specifying the column name containing temporal
+#'   weight parameters (default: "wt")
+#'
+#' @seealso [cal_wt()]
+#' @seealso [cal_lm_pH()]
+#' @seealso [cal_three_point_drift_pH()]
+
+cal_lin_trans_inv_lm_pH <- function(df = ., obs_col = "mean", mv_col = "mean_mV_f", lm_coefs_col = "calibration_coefs", wt_col = "wt") {
+
+  # Create output column names for pH conversion
+  ph_f <- paste0(str_split_1(mv_col, "_")[1], "_pH_f")
+
+  # Extract calibration coefficients from bounding calibrations
+  calibration_1 <- df[[lm_coefs_col]][[1]]
+  calibration_2 <- df[[lm_coefs_col]][[nrow(df)]]
+
+  # Handle missing calibration data
+  if (is.null(calibration_1) || is.null(calibration_2)){
+    df <- df %>%
+      mutate(!!ph_f := NA_integer_)
+    return(df)
+  }
+
+  # Extract parameters from first calibration (earliest)
+  cal_1_slopes <- calibration_1 %>% pull(slope)
+  cal_1_offsets <- calibration_1 %>% pull(offset)
+
+  cal_1_slope_1 <- as.numeric(cal_1_slopes[1])   # Low pH range slope
+  cal_1_offset_1 <- as.numeric(cal_1_offsets[1]) # Low pH range offset
+  cal_1_slope_2 <- as.numeric(cal_1_slopes[2])   # High pH range slope
+  cal_1_offset_2 <- as.numeric(cal_1_offsets[2]) # High pH range offset
+
+  # Extract parameters from second calibration (latest)
+  cal_2_slopes <- calibration_2 %>% pull(slope)
+  cal_2_offsets <- calibration_2 %>% pull(offset)
+
+  cal_2_slope_1 <- as.numeric(cal_2_slopes[1])   # Low pH range slope
+  cal_2_offset_1 <- as.numeric(cal_2_offsets[1]) # Low pH range offset
+  cal_2_slope_2 <- as.numeric(cal_2_slopes[2])   # High pH range slope
+  cal_2_offset_2 <- as.numeric(cal_2_offsets[2]) # High pH range offset
+
+  # Calculate parameter differences for temporal interpolation
+  slope_1_delta <- cal_1_slope_1 - cal_2_slope_1   # Low range slope difference
+  offset_1_delta <- cal_1_offset_1 - cal_2_offset_1 # Low range offset difference
+  slope_2_delta <- cal_1_slope_2 - cal_2_slope_2   # High range slope difference
+  offset_2_delta <- cal_1_offset_2 - cal_2_offset_2 # High range offset difference
+
+  # Convert millivolts back to pH using temporally-weighted inverse transformation
+  df <- df %>%
+    mutate(
+      # Inverse transformation for low pH range: x = (y-(b_1-wt(b_1-b_2)))/(m_1-wt(m_1-m_2))
+      ph_1 := (.data[[mv_col]] - (cal_1_offset_1 - (.data[[wt_col]] * offset_1_delta))) /
+        (cal_1_slope_1 - (.data[[wt_col]] * slope_1_delta)),
+      # Inverse transformation for high pH range: x = (y-(b_1-wt(b_1-b_2)))/(m_1-wt(m_1-m_2))
+      ph_2 := (.data[[mv_col]] - (cal_1_offset_2 - (.data[[wt_col]] * offset_2_delta))) /
+        (cal_1_slope_2 - (.data[[wt_col]] * slope_2_delta)),
+      # Select appropriate pH value based on original pH threshold (neutral = 7)
+      !!ph_f := ifelse(.data[[obs_col]] >= 7, !!ph_2, !!ph_1)
+    ) %>%
+    select(-c(ph_1, ph_2))  # Remove intermediate calculation columns
+
+  return(df)
+}

--- a/src/cal_lin_trans_inv_lm_pH.R
+++ b/src/cal_lin_trans_inv_lm_pH.R
@@ -32,7 +32,9 @@ cal_lin_trans_inv_lm_pH <- function(df = ., obs_col = "mean", mv_col = "mean_mV_
   calibration_2 <- df[[lm_coefs_col]][[nrow(df)]]
 
   # Handle missing calibration data
-  if (is.null(calibration_1) || is.null(calibration_2)){
+  cal_1_check <- (is.data.frame(calibration_1) && nrow(calibration_1) != 0)
+  cal_2_check <- (is.data.frame(calibration_2) && nrow(calibration_2) != 0)
+  if (!cal_1_check | !cal_2_check){
     df <- df %>%
       mutate(!!ph_f := NA_integer_)
     return(df)
@@ -66,13 +68,13 @@ cal_lin_trans_inv_lm_pH <- function(df = ., obs_col = "mean", mv_col = "mean_mV_
   df <- df %>%
     mutate(
       # Inverse transformation for low pH range: x = (y-(b_1-wt(b_1-b_2)))/(m_1-wt(m_1-m_2))
-      ph_1 := (.data[[mv_col]] - (cal_1_offset_1 - (.data[[wt_col]] * offset_1_delta))) /
+      ph_1 = (.data[[mv_col]] - (cal_1_offset_1 - (.data[[wt_col]] * offset_1_delta))) /
         (cal_1_slope_1 - (.data[[wt_col]] * slope_1_delta)),
       # Inverse transformation for high pH range: x = (y-(b_1-wt(b_1-b_2)))/(m_1-wt(m_1-m_2))
-      ph_2 := (.data[[mv_col]] - (cal_1_offset_2 - (.data[[wt_col]] * offset_2_delta))) /
+      ph_2 = (.data[[mv_col]] - (cal_1_offset_2 - (.data[[wt_col]] * offset_2_delta))) /
         (cal_1_slope_2 - (.data[[wt_col]] * slope_2_delta)),
       # Select appropriate pH value based on original pH threshold (neutral = 7)
-      !!ph_f := ifelse(.data[[obs_col]] >= 7, !!ph_2, !!ph_1)
+      !!ph_f := ifelse(.data[[obs_col]] >= 7, ph_2, ph_1)
     ) %>%
     select(-c(ph_1, ph_2))  # Remove intermediate calculation columns
 

--- a/src/cal_lin_trans_lm.R
+++ b/src/cal_lin_trans_lm.R
@@ -1,0 +1,57 @@
+#' @title Linear Transition Between Linear Models
+#'
+#' @description
+#' Applies temporally-weighted linear transformation between two consecutive
+#' calibrations. This function interpolates between the slope and offset
+#' parameters from calibration 1 (earliest) and calibration 2 (latest) using
+#' temporal weights to create a smooth transition across the calibration window.
+#' The transformation accounts for gradual sensor drift by blending calibration
+#' parameters based on time position.
+#'
+#' @param df Tibble containing sensor data bounded by two calibrations
+#' @param raw_col Character string specifying the column name containing raw
+#'   observation values from the inverse linear model transformation
+#' @param lm_coefs_col Character string specifying the column name containing
+#'   linear model coefficients
+#' @param wt_col Character string specifying the column name containing temporal
+#'   weight parameters
+#'
+#' @seealso [cal_wt()]
+#' @seealso [cal_inv_lm()]
+#' @seealso [cal_one_point_drift()]
+#' @seealso [cal_two_point_drift()]
+
+cal_lin_trans_lm <- function(df, raw_col, lm_coefs_col, wt_col){
+
+  # Create output column name for linearly transformed values
+  transformed_col <- paste0(str_split_1(raw_col, "_")[1], "_lm_trans")
+
+  # Extract calibration coefficients from bounding calibrations
+  calibration_1 <- df[[lm_coefs_col]][[1]]
+  calibration_2 <- df[[lm_coefs_col]][[nrow(df)]]
+
+  # Handle missing calibration data
+  if (is.null(calibration_1) || is.null(calibration_2)){
+    df <- df %>%
+      mutate(!!transformed_col := NA_integer_)
+    return(df)
+  }
+
+  # Extract parameters from first calibration (earliest)
+  slope_1 <- as.numeric(calibration_1 %>% pull(slope))
+  offset_1 <- as.numeric(calibration_1 %>% pull(offset))
+
+  # Extract parameters from second calibration (latest)
+  slope_2 <- as.numeric(calibration_2 %>% pull(slope))
+  offset_2 <- as.numeric(calibration_2 %>% pull(offset))
+
+  # Calculate parameter differences for temporal interpolation
+  slope_delta <- slope_1 - slope_2
+  offset_delta <- offset_1 - offset_2
+
+  # Apply temporally-weighted linear model: y = (m_1-wt(m_1-m_2))x+(b_1-wt(b_1-b_2))
+  df <- df %>%
+    mutate(!!transformed_col := ((slope_1-(.data[[wt_col]]*slope_delta))*.data[[raw_col]])+(offset_1-(.data[[wt_col]]*offset_delta)))
+
+  return(df)
+}

--- a/src/cal_lin_trans_lm.R
+++ b/src/cal_lin_trans_lm.R
@@ -31,7 +31,9 @@ cal_lin_trans_lm <- function(df, raw_col, lm_coefs_col, wt_col){
   calibration_2 <- df[[lm_coefs_col]][[nrow(df)]]
 
   # Handle missing calibration data
-  if (is.null(calibration_1) || is.null(calibration_2)){
+  cal_1_check <- (is.data.frame(calibration_1) && nrow(calibration_1) != 0)
+  cal_2_check <- (is.data.frame(calibration_2) && nrow(calibration_2) != 0)
+  if (!cal_1_check | !cal_2_check){
     df <- df %>%
       mutate(!!transformed_col := NA_integer_)
     return(df)

--- a/src/cal_lm_pH.R
+++ b/src/cal_lm_pH.R
@@ -27,7 +27,7 @@ cal_lm_pH <- function(df, obs_col, lm_coefs_col) {
   calibration_1 <- df[[lm_coefs_col]][[1]]
 
   # Handle missing calibration data
-  if (is.null(calibration_1)) {
+  if (!is.data.frame(calibration_1) || nrow(calibration_1) == 0) {
     df <- df %>%
       mutate(!!mv_f := NA_integer_)
     return(df)
@@ -51,7 +51,7 @@ cal_lm_pH <- function(df, obs_col, lm_coefs_col) {
       # Apply linear transformation for high pH range: y = mx + b
       mv_2 = (slope_2 * .data[[obs_col]]) + offset_2,
       # Select appropriate mV value based on pH threshold (neutral = 7)
-      !!mv_f := ifelse(.data[[obs_col]] >= 7, .data[[mv_2]], .data[[mv_1]])
+      !!mv_f := ifelse(.data[[obs_col]] >= 7, mv_2, mv_1)
     ) %>%
     select(-c(mv_1, mv_2))  # Remove intermediate calculation columns
 

--- a/src/cal_lm_pH.R
+++ b/src/cal_lm_pH.R
@@ -1,0 +1,59 @@
+#' @title pH Linear Model Transformation
+#'
+#' @description
+#' Converts pH observations to millivolt units using two-segment linear models
+#' from three-point pH calibration. This function applies forward linear
+#' transformation (pH to mV) to enable subsequent back-calibration processing
+#' in the correct instrumental units. Uses pH value thresholds to select
+#' between low-range and high-range linear segments based on the sensor's
+#' three-point calibration characteristics.
+#'
+#' @param df Tibble containing sensor data bounded by two calibrations
+#' @param obs_col Character string specifying the column name containing pH
+#'   observations recorded in HydroVu
+#' @param lm_coefs_col Character string specifying the column name containing
+#'   linear model coefficients with two slope/offset pairs
+#'
+#' @seealso [cal_wt()]
+#' @seealso [cal_lin_trans_inv_lm_pH()]
+#' @seealso [cal_three_point_drift_pH()]
+
+cal_lm_pH <- function(df, obs_col, lm_coefs_col) {
+
+  # Create output column names for pH to mV conversion
+  mv_f <- paste0(obs_col, "_mV_f")
+
+  # Extract calibration coefficients from first calibration
+  calibration_1 <- df[[lm_coefs_col]][[1]]
+
+  # Handle missing calibration data
+  if (is.null(calibration_1)) {
+    df <- df %>%
+      mutate(!!mv_f := NA_integer_)
+    return(df)
+  }
+
+  # Extract slope and offset parameters for two-segment calibration
+  slopes <- calibration_1 %>% pull(slope)
+  offsets <- calibration_1 %>% pull(offset)
+
+  slope_1 <- as.numeric(slopes[1])   # Low pH range slope (mV/pH)
+  offset_1 <- as.numeric(offsets[1]) # Low pH range offset (mV)
+
+  slope_2 <- as.numeric(slopes[2])   # High pH range slope (mV/pH)
+  offset_2 <- as.numeric(offsets[2]) # High pH range offset (mV)
+
+  # Convert pH to millivolts using two-segment linear models
+  df <- df %>%
+    mutate(
+      # Apply linear transformation for low pH range: y = mx + b
+      mv_1 = (slope_1 * .data[[obs_col]]) + offset_1,
+      # Apply linear transformation for high pH range: y = mx + b
+      mv_2 = (slope_2 * .data[[obs_col]]) + offset_2,
+      # Select appropriate mV value based on pH threshold (neutral = 7)
+      !!mv_f := ifelse(.data[[obs_col]] >= 7, .data[[mv_2]], .data[[mv_1]])
+    ) %>%
+    select(-c(mv_1, mv_2))  # Remove intermediate calculation columns
+
+  return(df)
+}

--- a/src/cal_one_point_drift.R
+++ b/src/cal_one_point_drift.R
@@ -28,6 +28,13 @@ cal_one_point_drift <- function(df, lm_trans_col, drift_corr_col, wt_col){
   # Extract drift calibration data from the latest calibration
   drift_back_calibration <- df[[drift_corr_col]][[nrow(df)]]
 
+  # Handle missing calibration data
+  if (!is.data.frame(drift_back_calibration) || nrow(drift_back_calibration) == 0) {
+    df <- df %>%
+      mutate(!!transformed_col := NA_integer_)
+    return(df)
+  }
+
   # Extract calibration standard values for drift calculation
   expected_standard <- as.numeric(drift_back_calibration %>% pull(post_measurement))
   observed_standard <- as.numeric(drift_back_calibration %>% pull(pre_measurement))

--- a/src/cal_one_point_drift.R
+++ b/src/cal_one_point_drift.R
@@ -1,0 +1,43 @@
+#' @title One Point Drift Calibration
+#'
+#' @description
+#' Applies single-point drift correction using pre- and post-measurement
+#' calibration standards. This function corrects for sensor drift by calculating
+#' the difference between expected and observed standard values, then applying a
+#' temporally-weighted correction across the calibration window. Used primarily
+#' for Chlorophyll-a, FDOM, ORP, Pressure, Specific Conductivity, and RDO
+#' sensors that require single-point drift correction.
+#'
+#' @param df Tibble containing sensor data bounded by two calibrations
+#' @param lm_trans_col Character string specifying the column name containing
+#'   linearly transformed data from cal_lin_trans_lm()
+#' @param drift_corr_col Character string specifying the column name containing
+#'   drift correction information
+#' @param wt_col Character string specifying the column name containing temporal
+#'   weight parameters
+#'
+#' @seealso [cal_wt()]
+#' @seealso [cal_lin_trans_lm()]
+#' @seealso [cal_check()]
+
+cal_one_point_drift <- function(df, lm_trans_col, drift_corr_col, wt_col){
+
+  # Create output column name for drift-corrected values
+  transformed_col <- paste0(str_split_1(lm_trans_col, "_")[1], "_drift_trans")
+
+  # Extract drift calibration data from the latest calibration
+  drift_back_calibration <- df[[drift_corr_col]][[nrow(df)]]
+
+  # Extract calibration standard values for drift calculation
+  expected_standard <- as.numeric(drift_back_calibration %>% pull(post_measurement))
+  observed_standard <- as.numeric(drift_back_calibration %>% pull(pre_measurement))
+
+  # Calculate drift offset between expected and observed standards
+  standard_delta <- expected_standard - observed_standard
+
+  # Apply temporally-weighted drift correction: C_t = m_t + w_t(delta_S)
+  df <- df %>%
+    mutate(!!transformed_col := .data[[lm_trans_col]] + (.data[[wt_col]]*standard_delta))
+
+  return(df)
+}

--- a/src/cal_prepare_sensor_calibration_data.R
+++ b/src/cal_prepare_sensor_calibration_data.R
@@ -1,0 +1,58 @@
+#' @title Prepare Sensor Calibration Data for Back Calibration
+#'
+#' @description
+#' Segments joined sensor-calibration data into calibration windows bounded by
+#' consecutive calibrations. This function creates data chunks where each chunk
+#' contains sensor data from one calibration period plus the first row from the
+#' next calibration, enabling temporal interpolation between calibration
+#' parameters. Processes data hierarchically by year and site-parameter
+#' combinations to maintain organization structure.
+#'
+#' @param sensor_calibration_data_list Nested list containing joined sensor and
+#'   calibration data from join_sensor_calibration_data(), organized by year
+#'   and site-parameter combinations
+#'
+#' @seealso [join_sensor_calibration_data()]
+#' @seealso [back_calibrate()]
+
+cal_prepare_sensor_calibration_data <- function(sensor_calibration_data_list) {
+
+  # Process each year of joined sensor-calibration data
+  prepped_yearly_site_param_chunks <- sensor_calibration_data_list %>%
+    map(function(year){ # Iterate over each year's site-parameter list
+
+      # Process each site-parameter combination within the year
+      prepped_yearly_site_param_chunks <- year %>%
+        map(function(site_param_df){
+
+          # Split data by calibration dates to create calibration periods
+          calibration_chunks <- site_param_df %>%
+            group_by(file_date) %>%
+            group_split() %>%
+            discard(~all(is.na(.x$sonde_serial)))  # Remove chunks with missing sonde data
+
+          # Handle single calibration case (no temporal interpolation needed)
+          if(length(calibration_chunks) == 1) return(calibration_chunks)
+
+          # Create calibration windows by pairing consecutive calibrations
+          chunks <- c(1:(length(calibration_chunks) - 1))
+          prepped_calibration_chunks <- chunks %>%
+            map(function(chunk) {
+              # Get current calibration period data
+              cal_1 <- calibration_chunks[[chunk]]
+              # Get first row of next calibration for temporal boundary
+              cal_2 <- slice(calibration_chunks[[chunk + 1]], 1)
+              # Combine to create calibration window bounded by two calibrations
+              prepped_chunk <- bind_rows(cal_1, cal_2)
+              return(prepped_chunk)
+            })
+
+          return(prepped_calibration_chunks)
+        })
+    })
+
+  # Return nested structure: year -> site-parameter -> calibration chunks
+  # Each chunk contains sensor data bounded by two consecutive calibrations
+  # enabling temporal interpolation of calibration parameters
+  return(prepped_yearly_site_param_chunks)
+}

--- a/src/cal_three_point_drift_pH.R
+++ b/src/cal_three_point_drift_pH.R
@@ -32,7 +32,7 @@ cal_three_point_drift_pH <- function(df, obs_col, lm_trans_col, drift_corr_col, 
   drift_back_calibration <- df[[drift_corr_col]][[nrow(df)]]
 
   # Handle missing drift calibration data
-  if (is.null(drift_back_calibration)){
+  if (!is.data.frame(drift_back_calibration) || nrow(drift_back_calibration) == 0){
     df <- df %>%
       mutate(!!drift_f := NA_integer_)
     return(df)
@@ -82,7 +82,7 @@ cal_three_point_drift_pH <- function(df, obs_col, lm_trans_col, drift_corr_col, 
       drift_1 = ((.data[[lm_trans_col]] - a_t) / (b_t - a_t)) * (b_e - a_e) + a_e,  # Low-medium range
       drift_2 = ((.data[[lm_trans_col]] - b_t) / (c_t - b_t)) * (c_e - b_e) + b_e,  # Medium-high range
       # Select appropriate correction based on original pH value
-      !!drift_f := ifelse(.data[[obs_col]] >= 7, !!drift_2, !!drift_1)
+      !!drift_f := ifelse(.data[[obs_col]] >= 7, drift_2, drift_1)
     ) %>%
     select(-c(a_t, b_t, c_t, drift_1, drift_2))  # Remove intermediate columns
 

--- a/src/cal_three_point_drift_pH.R
+++ b/src/cal_three_point_drift_pH.R
@@ -1,0 +1,90 @@
+#' @title Three Point Drift Calibration (pH Specific)
+#'
+#' @description
+#' Applies three-point drift correction using low, medium, and high pH calibration
+#' buffers. This function corrects for sensor drift by performing piecewise linear
+#' interpolation across three calibration points, accounting for non-linear drift
+#' patterns across the pH measurement range. Used specifically for pH sensors that
+#' require three-point calibration due to their multi-segment response
+#' characteristics.
+#'
+#' @param df Tibble containing sensor data bounded by two calibrations
+#' @param obs_col Character string specifying the column name containing original
+#'   pH observations for drift selection logic
+#' @param lm_trans_col Character string specifying the column name containing
+#'   linearly transformed data from pH-specific transformation functions
+#' @param drift_corr_col Character string specifying the column name containing
+#'   drift correction information
+#' @param wt_col Character string specifying the column name containing temporal
+#'   weight parameters
+#'
+#' @seealso [cal_wt()]
+#' @seealso [cal_lm_pH()]
+#' @seealso [cal_lin_trans_inv_lm_pH()]
+#' @seealso [cal_check()]
+
+cal_three_point_drift_pH <- function(df, obs_col, lm_trans_col, drift_corr_col, wt_col) {
+
+  # Create output column names for drift calculations
+  drift_f <- paste0(str_split_1(lm_trans_col, "_")[1], "_drift_f")
+
+  # Extract drift calibration data from the latest calibration
+  drift_back_calibration <- df[[drift_corr_col]][[nrow(df)]]
+
+  # Handle missing drift calibration data
+  if (is.null(drift_back_calibration)){
+    df <- df %>%
+      mutate(!!drift_f := NA_integer_)
+    return(df)
+  }
+
+  # Filter drift data to relevant columns
+  drift_back_calibration <- drift_back_calibration %>%
+    select(point, type, p_h)
+
+  # Extract expected values for the three pH standards (type == 2)
+  expected_standards <- drift_back_calibration %>%
+    group_by(point) %>%
+    filter(type == 2) %>%
+    pull(p_h)
+
+  a_e <- as.numeric(expected_standards[1])  # Low pH standard expected
+  b_e <- as.numeric(expected_standards[2])  # Medium pH standard expected
+  c_e <- as.numeric(expected_standards[3])  # High pH standard expected
+
+  # Calculate expected ranges between standards
+  delta_e_ab <- b_e - a_e  # Low to medium range
+  delta_e_bc <- c_e - b_e  # Medium to high range
+
+  # Extract observed values for the three pH standards (type == 1)
+  observed_standards <- drift_back_calibration %>%
+    group_by(point) %>%
+    filter(type == 1) %>%
+    pull(p_h)
+
+  a_o <- as.numeric(observed_standards[1])  # Low pH standard observed
+  b_o <- as.numeric(observed_standards[2])  # Medium pH standard observed
+  c_o <- as.numeric(observed_standards[3])  # High pH standard observed
+
+  # Calculate drift offsets for each standard
+  delta_a <- a_e - a_o  # Low standard drift
+  delta_b <- b_e - b_o  # Medium standard drift
+  delta_c <- c_e - c_o  # High standard drift
+
+  # Apply temporally-weighted three-point drift correction
+  df <- df %>%
+    mutate(
+      # Calculate temporally-adjusted standard values
+      a_t = a_e + (.data[[wt_col]] * delta_a),  # Weighted low standard
+      b_t = b_e + (.data[[wt_col]] * delta_b),  # Weighted medium standard
+      c_t = c_e + (.data[[wt_col]] * delta_c),  # Weighted high standard
+      # Calculate piecewise linear corrections for each pH range
+      drift_1 = ((.data[[lm_trans_col]] - a_t) / (b_t - a_t)) * (b_e - a_e) + a_e,  # Low-medium range
+      drift_2 = ((.data[[lm_trans_col]] - b_t) / (c_t - b_t)) * (c_e - b_e) + b_e,  # Medium-high range
+      # Select appropriate correction based on original pH value
+      !!drift_f := ifelse(.data[[obs_col]] >= 7, !!drift_2, !!drift_1)
+    ) %>%
+    select(-c(a_t, b_t, c_t, drift_1, drift_2))  # Remove intermediate columns
+
+  return(df)
+}

--- a/src/cal_two_point_drift.R
+++ b/src/cal_two_point_drift.R
@@ -1,0 +1,60 @@
+#' @title Two Point Drift Calibration
+#'
+#' @description
+#' Applies two-point drift correction using low and high calibration standards.
+#' This function corrects for sensor drift by calculating linear interpolation
+#' between two calibration points, accounting for drift in both standards across
+#' the calibration window. Used specifically for turbidity sensors that require
+#' two-point drift correction to handle non-linear drift patterns across the
+#' measurement range.
+#'
+#' @param df Tibble containing sensor data bounded by two calibrations
+#' @param lm_trans_col Character string specifying the column name containing
+#'   linearly transformed data from cal_lin_trans_lm()
+#' @param drift_corr_col Character string specifying the column name containing
+#'   drift correction information
+#' @param wt_col Character string specifying the column name containing temporal
+#'   weight parameters
+#'
+#' @seealso [cal_wt()]
+#' @seealso [cal_lin_trans_lm()]
+#' @seealso [cal_check()]
+
+cal_two_point_drift <- function(df, lm_trans_col, drift_corr_col, wt_col){
+
+  # Create output column name for drift-corrected values
+  transformed_col <- paste0(str_split_1(lm_trans_col, "_")[1], "_drift_trans")
+
+  # Extract drift calibration data from the latest calibration
+  drift_back_calibration <- df[[drift_corr_col]][[nrow(df)]]
+
+  # Extract expected values for calibration standards
+  s_e <- drift_back_calibration %>% pull(post_measurement)
+  a_e <- as.numeric(s_e[1]) # Low standard expected
+  b_e <- as.numeric(s_e[2]) # High standard expected
+
+  # Calculate expected range between standards
+  delta_e <- b_e - a_e
+
+  # Extract observed values for calibration standards
+  s_o <- drift_back_calibration %>% pull(pre_measurement)
+  a_o <- as.numeric(s_o[1])  # Low standard observed
+  b_o <- as.numeric(s_o[2])  # High standard observed
+
+  # Calculate drift offsets for each standard
+  delta_a <- a_e - a_o  # Low standard drift
+  delta_b <- b_e - b_o  # High standard drift
+
+  # Apply temporally-weighted two-point drift correction
+  df <- df %>%
+    mutate(
+      # Calculate temporally-adjusted standard values
+      a_t = a_e - (.data[[wt_col]] * delta_a),  # Weighted low standard
+      b_t = b_e - (.data[[wt_col]] * delta_b),  # Weighted high standard
+      # Apply linear interpolation drift correction: C_t = ((m_t-a_t)/(b_t-a_t))(b_e-a_e)+a_e
+      !!transformed_col := (((.data[[lm_trans_col]] - a_t) / (b_t - a_t)) * delta_e) + a_e
+    ) %>%
+    select(-c(a_t, b_t))  # Remove intermediate calculation columns
+
+  return(df)
+}

--- a/src/cal_two_point_drift.R
+++ b/src/cal_two_point_drift.R
@@ -28,6 +28,13 @@ cal_two_point_drift <- function(df, lm_trans_col, drift_corr_col, wt_col){
   # Extract drift calibration data from the latest calibration
   drift_back_calibration <- df[[drift_corr_col]][[nrow(df)]]
 
+  # Handle missing calibration data
+  if (!is.data.frame(drift_back_calibration) || nrow(drift_back_calibration) == 0) {
+    df <- df %>%
+      mutate(!!transformed_col := NA_integer_)
+    return(df)
+  }
+
   # Extract expected values for calibration standards
   s_e <- drift_back_calibration %>% pull(post_measurement)
   a_e <- as.numeric(s_e[1]) # Low standard expected

--- a/src/cal_wt.R
+++ b/src/cal_wt.R
@@ -1,0 +1,33 @@
+#' @title Temporal Weight Factor Calculation
+#'
+#' @description
+#' Calculates temporal weight factors for linear interpolation between consecutive
+#' calibrations. This function creates a weight column that assigns values from 0
+#' (earliest time) to 1 (latest time) within each calibration window, enabling
+#' time-weighted transitions between calibration parameters. Inspired by the
+#' driftR package's dr_factor function.
+#'
+#' @param df Tibble containing sensor data bounded by two calibrations
+#' @param dt_col Character string specifying the column name containing POSIXct
+#'   datetime information
+#' @param wt_col Character string specifying the name for the created weight
+#'   column (default: "wt")
+#'
+#' @seealso [cal_lin_trans_lm()]
+#' @seealso [cal_one_point_drift()]
+#' @seealso [cal_two_point_drift()]
+#' @seealso [cal_three_point_drift_pH()]
+
+cal_wt <- function(df, dt_col, wt_col = "wt"){
+
+  # Extract temporal boundaries for the calibration window
+  first_dt <- min(df[[dt_col]])
+  last_dt <- max(df[[dt_col]])
+  tot_time <- as.numeric(difftime(last_dt, first_dt, units = "mins"))
+
+  # Calculate temporal weight factors (0 to 1) for linear interpolation
+  df <- df %>%
+    mutate(!!wt_col := as.numeric(difftime(.data[[dt_col]], first_dt, units = "mins"))/tot_time)
+
+  return(df)
+}

--- a/src/load_calibration_data.R
+++ b/src/load_calibration_data.R
@@ -1,0 +1,55 @@
+#' @title Load Calibration Data
+#'
+#' @description
+#' Loads or generates calibration coefficient and drift correction data from
+#' HTML calibration files. This function manages calibration data by either
+#' loading existing processed data or extracting fresh data from source HTML
+#' files. Creates a global calibration_data object organized by year and
+#' site-parameter combinations for use throughout the calibration workflow.
+#'
+#' @param cal_data_file_path Character string specifying the file path for
+#'   saved calibration data RDS file (default: munged_calibration_data.RDS
+#'   in data/calibration_reports/0_cal_data_munge/)
+#' @param update Logical flag indicating whether to regenerate calibration data
+#'   from source HTML files (default: FALSE)
+#' @param ... Additional arguments passed to underlying calibration extraction
+#'   functions
+#'
+#' @seealso [cal_extract_markup_data()]
+#' @seealso [join_sensor_calibration_data()]
+
+load_calibration_data <- function(cal_data_file_path = here("data", "calibration_reports", "0_cal_data_munge", "munged_calibration_data.RDS"),
+                                  update = FALSE, ...){
+
+  # Load existing calibration data (typical usage)
+  if (file.exists(cal_data_file_path) & !update) {
+    message("Calibration data exists! Loading calibration_data...")
+    calibration_data <<- read_rds(cal_data_file_path)
+    message("The calibration data will not be updated.")
+  }
+
+  # Force update of existing calibration data
+  if (update) {
+    message("Generating the calibration data, this may take a second...")
+    calibration_data <<- cal_extract_markup_data()
+    write_rds(calibration_data, cal_data_file_path)
+    message("The updated calibration data is saved in ", cal_data_file_path)
+  }
+
+  # Generate and save calibration data when file doesn't exist and update requested
+  if (!file.exists(cal_data_file_path) & update) {
+    message("Calibration data does not exist!")
+    message("Generating the calibration data, this may take a second...")
+    calibration_data <<- cal_extract_markup_data()
+    write_rds(calibration_data, cal_data_file_path)
+    message("The generated calibration data is saved in ", cal_data_file_path)
+  }
+
+  # Generate calibration data without saving when file doesn't exist and no update requested
+  if (!file.exists(cal_data_file_path) & !update) {
+    message("Calibration data does not exist!")
+    message("Generating the calibration data, this may take a second...")
+    calibration_data <<- cal_extract_markup_data()
+    message("The generated calibration data is not saved in ", cal_data_file_path)
+  }
+}

--- a/src/load_calibration_data.R
+++ b/src/load_calibration_data.R
@@ -19,37 +19,83 @@
 #' @seealso [join_sensor_calibration_data()]
 
 load_calibration_data <- function(cal_data_file_path = here("data", "calibration_reports", "0_cal_data_munge", "munged_calibration_data.RDS"),
-                                  update = FALSE, ...){
+                                  update = FALSE, ...) {
 
-  # Load existing calibration data (typical usage)
-  if (file.exists(cal_data_file_path) & !update) {
+  # Input validation
+  if (!is.character(cal_data_file_path) || length(cal_data_file_path) != 1) {
+    stop("cal_data_file_path must be a single character string")
+  }
+
+  if (!is.logical(update) || length(update) != 1) {
+    stop("update must be a single logical value (TRUE or FALSE)")
+  }
+
+  # Check if directory exists, create if needed
+  cal_data_dir <- dirname(cal_data_file_path)
+  if (!dir.exists(cal_data_dir)) {
+    message("Creating directory: ", cal_data_dir)
+    dir.create(cal_data_dir, recursive = TRUE, showWarnings = FALSE)
+  }
+
+  # Check if file exists
+  file_exists <- file.exists(cal_data_file_path)
+
+  if (file_exists && !update) {
+    # Load existing calibration data (typical usage)
     message("Calibration data exists! Loading calibration_data...")
-    calibration_data <<- read_rds(cal_data_file_path)
-    message("The calibration data will not be updated.")
+
+    tryCatch({
+      calibration_data <<- readr::read_rds(cal_data_file_path)
+      message("Successfully loaded calibration data from: ", cal_data_file_path)
+    }, error = function(e) {
+      stop("Failed to load calibration data from ", cal_data_file_path,
+           ". Error: ", e$message)
+    })
+
+  } else if (update || !file_exists) {
+    # Generate calibration data (either forced update or file doesn't exist)
+    if (!file_exists) {
+      message("Calibration data does not exist!")
+    }
+    message("Generating the calibration data, this may take a second...")
+
+    # Check if cal_extract_markup_data function exists
+    if (!exists("cal_extract_markup_data", mode = "function")) {
+      stop("cal_extract_markup_data function not found. Please ensure all calibration functions are sourced.")
+    }
+
+    tryCatch({
+      calibration_data <<- cal_extract_markup_data(...)
+
+      # Validate generated data
+      if (is.null(calibration_data) || length(calibration_data) == 0) {
+        stop("cal_extract_markup_data returned empty or NULL data")
+      }
+
+      message("Successfully generated calibration data")
+
+    }, error = function(e) {
+      stop("Failed to generate calibration data. Error: ", e$message)
+    })
+
+    # Save data if update was requested or file didn't exist
+    if (update || !file_exists) {
+      tryCatch({
+        readr::write_rds(calibration_data, cal_data_file_path)
+        message("Calibration data saved to: ", cal_data_file_path)
+      }, error = function(e) {
+        warning("Generated calibration data successfully but failed to save to ",
+                cal_data_file_path, ". Error: ", e$message)
+      })
+    } else {
+      message("Generated calibration data not saved (update = FALSE)")
+    }
   }
 
-  # Force update of existing calibration data
-  if (update) {
-    message("Generating the calibration data, this may take a second...")
-    calibration_data <<- cal_extract_markup_data()
-    write_rds(calibration_data, cal_data_file_path)
-    message("The updated calibration data is saved in ", cal_data_file_path)
+  # Final validation that calibration_data exists in global environment
+  if (!exists("calibration_data", envir = .GlobalEnv)) {
+    stop("Failed to create calibration_data object in global environment")
   }
 
-  # Generate and save calibration data when file doesn't exist and update requested
-  if (!file.exists(cal_data_file_path) & update) {
-    message("Calibration data does not exist!")
-    message("Generating the calibration data, this may take a second...")
-    calibration_data <<- cal_extract_markup_data()
-    write_rds(calibration_data, cal_data_file_path)
-    message("The generated calibration data is saved in ", cal_data_file_path)
-  }
-
-  # Generate calibration data without saving when file doesn't exist and no update requested
-  if (!file.exists(cal_data_file_path) & !update) {
-    message("Calibration data does not exist!")
-    message("Generating the calibration data, this may take a second...")
-    calibration_data <<- cal_extract_markup_data()
-    message("The generated calibration data is not saved in ", cal_data_file_path)
-  }
+  message("Calibration data ready for use")
 }


### PR DESCRIPTION
Hey Katie, sorry for this behemoth PR, hopefully it's easy to follow along.

Sam I am adding you for the exposure, I am not expecting a full review from you :).

AI disclosure: I did use AI to generate this PR description, and then I edited it

----
This PR implements the back-calibration system for water quality sensor data from In-Situ Aqua TROLL sondes. The system corrects sensor readings by applying slope/offset corrections from HTML calibration files and temporal interpolation between calibrations to generate the calibrated time series data.

**Note:** While drift correction functions (very much inspired by the driftR package) are implemented and remain in the workflow, I am using the linear interpolation corrections as the primary calibration method.

## Files Added/Modified

### New Core Functions (`src/`)
- `load_calibration_data.R` - Main data loading interface
- `cal_extract_markup_data.R` - HTML parsing and extraction (_heavily_ modified)
    - This function holds the calibration extraction stuff from the previous PR and incorporates the bench top integrations. Important stuff, please pay special attention to this in the review, since if this is not good, then the downstream stuff is not good. 
- `cal_join_sensor_calibration_data.R` - Temporal data joining 
- `cal_prepare_sensor_calibration_data.R` - Calibration window creation
- `cal_back_calibrate.R` - Main orchestrator function

### New Calibration Processing Functions (`src/`)
- `cal_wt.R` - Temporal weight calculation
- `cal_inv_lm.R` - Inverse linear model transformation
- `cal_lin_trans_lm.R` - Linear transformation with temporal weighting
- `cal_lm_pH.R` - pH-specific linear model (pH → mV conversion)
- `cal_lin_trans_inv_lm_pH.R` - pH-specific inverse transformation (mV → pH)
- `cal_check.R` - Validation and final value selection

### New Drift Correction Functions (`src/`)
- `cal_one_point_drift.R` - Single-point drift correction (most sensors)
- `cal_two_point_drift.R` - Two-point drift correction (turbidity)
- `cal_three_point_drift_pH.R` - Three-point drift correction (pH)

## Reviewing suggestions

### 1. **Check the data flow**
Follow this sequence to understand data processing:
```
load_calibration_data() → cal_join_sensor_calibration_data() → 
cal_prepare_sensor_calibration_data() → cal_back_calibrate()
```

### 2. **Review the orchestrator function to  understand the core calibration sequence**
Review `cal_back_calibrate.R` to understand the three calibration pathways:
- Standard sensors (Simple linear transformation + 1-point drift)
- Turbidity sensors (Simple linear transformation + 2-point drift)
- pH sensors (Multi-segment calibration with mV↔pH conversions + 3-point multi-segment drift)

For standard sensors, review these functions in order:
```
cal_wt() → cal_inv_lm() → cal_lin_trans_lm() → 
cal_one_point_drift() → cal_check()
```

#### Key Features to Review

##### **Temporal Interpolation**
- `cal_wt()` creates weights (0→1) across calibration windows
- `cal_lin_trans_lm()` applies weighted interpolation between calibration parameters
- This enables smooth transitions between calibrations over time

Turbidity is very similar, but with a 2-point drift calibration, but since we are not considering the drift corrections right now, that one should be a quick review. 

### 3. **pH-specific workflow**
pH sensors require special attention due to unit conversions:
```
cal_wt() → cal_lm_pH() → cal_lin_trans_inv_lm_pH() → 
cal_three_point_drift_pH() → cal_check()
```
The slope and offset information requires a unit conversion and then a multi-segment linear transition. Weird stuff, and I am not sure that this was done correctly since the Nernst equation that is used by the sensors to get the pH reading requires temperature to get the value. I am not sure that I can just convert these values to their "raw" readings in the same way as the other parameters without temperature information. But assuming that I don't have to do that I was able to do a linear transformation on the data, similar to the linear transitions we do for the other parameters. The pH stuff is the shakiest component in the PR, so special attention there would be appreciated. ~Though, I would not be surprised if those functions just don't work in their current state.~ The pH workflow should run without errors now, but that does not mean that the logic is perfectly sound, so a review on that is still needed. 

### 4. **Review the outputs from the examples in the workflow:**
~I did not explore many more options, though I am sure that there are other options that you can test. I did not test any pH yet. But for these examples check that the outputs and logic of the workflow make sense.~ 

You should be able to review all the outputs from the calibration workflow. There is still some stuff that needs to get fixed (Spc NA offsets → 0, checking if the structure for inputs is _more_ correct, joining on site visits, etc.), but this workflow is in a stable spot now in terms of execution and syntactical errors, but it's logic needs to be reviewed still.

### 5. **Verify function documentation:**
AI disclosure: I used AI to write the documentation for the functions and the comments within the functions. I did read them over to verify their accuracy, but if you spot anything that looks suspicious please flag it. 

**Note on error handling**
- ~I will need to add more robust error handling to handle whatever edge cases may arise as I continue to test. This is why the back calibration step breaks on the older data, haven't handled those edge cases.~ 
- The execution errors should be handled for the data that we have. The error handling is mainly around the calibration function inputs, so there is a lot that is not accounted for still but the script runs now. 

This PR is big so if you would like to talk about it or review any part of it IRL let me know. Thanks, Katie!

